### PR TITLE
ENH: Prepare for LIVE Deployment

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,45 +27,12 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://nvidia/cuda:11.2.1-devel-ubuntu20.04
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # Install LaTeX (Support for matplotlib)
-      - name: Install latex dependencies
-        shell: bash -l {0}
-        run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            ghostscript               \
-            cm-super
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.9
-          environment-file: environment.yml
-          activate-environment: quantecon
-      - name: Install Jax and Upgrade CUDA
-        shell: bash -l {0}
-        run: |
-          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          nvidia-smi
       - name: Build HTML
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,13 +41,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v2
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,104 +24,56 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://nvidia/cuda:11.8.0-devel-ubuntu22.04
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # Install LaTeX (Support for matplotlib and PDF builds)
-      - name: Install latex dependencies
+      # Check nvidia-smi
+      - name: Check nvidia drivers
         shell: bash -l {0}
         run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy                     \
-            dvipng                    \
-            ghostscript               \
-            cm-super
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: 3.9
-          environment-file: environment.yml
-          activate-environment: quantecon
-      - name: Install Jax and Upgrade CUDA
-        shell: bash -l {0}
-        run: |
-          pip install --upgrade "jax[cuda]==0.4.2" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "numpyro[cuda]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           nvidia-smi
-      - name: Install latex dependencies
-        shell: bash -l {0}
-        run: |
-          apt-get -qq update
-          export DEBIAN_FRONTEND=noninteractive
-          apt-get install -y tzdata
-          apt-get install -y     \
-            texlive-latex-recommended \
-            texlive-latex-extra       \
-            texlive-fonts-recommended \
-            texlive-fonts-extra       \
-            texlive-xetex             \
-            latexmk                   \
-            xindy
       - name: Display Conda Environment Versions
         shell: bash -l {0}
         run: conda list
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v2
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
-      # Build Assets (Download Notebooks and PDF via LaTeX)
-      - name: Build PDF from LaTeX
-        shell: bash -l {0}
-        run: |
-          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
-          mkdir -p _build/html/_pdf
-          cp -u _build/latex/*.pdf _build/html/_pdf
-      - name: Upload Execution Reports (LaTeX)
-        uses: actions/upload-artifact@v2
-        if: failure()
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
         with:
-          name: execution-reports
-          path: _build/latex/reports
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
+      # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
           mkdir -p _build/html/_notebooks
           cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Build PDF from LaTeX
+        shell: bash -l {0}
+        run: |
+          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
+          mkdir _build/html/_pdf
+          cp -u _build/latex/*.pdf _build/html/_pdf
       # Final Build of HTML
       - name: Build HTML
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./ -n -W --keep-going
-      - name: Upload Execution Reports (HTML)
+      - name: Upload Execution Reports
         uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: execution-reports
           path: _build/html/reports
       - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v2
         with:
           publish-dir: '_build/html/'
           production-branch: main

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,44 @@
+name: Link Checker [Anaconda, Linux]
+on:
+  pull_request:
+    types: [opened, reopened]
+  schedule:
+    # UTC 12:00 is early morning in Australia
+    - cron:  '0 12 * * *'
+jobs:
+  link-check-linux:
+    name: Link Checking (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.9"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Anaconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: "3.10"
+          environment-file: environment.yml
+          activate-environment: quantecon
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
+      - name: Link Checker
+        shell: bash -l {0}
+        run: jb build lectures --path-output=./ --builder=custom --custom-builder=linkcheck
+      - name: Upload Link Checker Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: linkcheck-reports
+          path: _build/linkcheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,111 @@
+name: Build & Publish to GH Pages
+on:
+  push:
+    tags:
+      - 'publish*'
+jobs:
+  deploy-runner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: iterative/setup-cml@v1
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Deploy runner on EC2
+        env:
+          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          cml runner launch \
+              --cloud=aws \
+              --cloud-region=us-west-2 \
+              --cloud-type=p3.2xlarge \
+              --labels=cml-gpu \
+              --cloud-hdd-size=40
+  publish:
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs: deploy-runner
+    runs-on: [self-hosted, cml-gpu]
+    container:
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310-b
+      options: --gpus all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      # Check nvidia-smi
+      - name: Check nvidia drivers
+        shell: bash -l {0}
+        run: |
+          nvidia-smi
+      - name: Display Conda Environment Versions
+        shell: bash -l {0}
+        run: conda list
+      - name: Display Pip Versions
+        shell: bash -l {0}
+        run: pip list
+      # Download Build Cache from cache.yml
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
+      # Build Assets (Download Notebooks, PDF via LaTeX)
+      - name: Build PDF from LaTeX
+        shell: bash -l {0}
+        run: |
+          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
+      - name: Copy LaTeX PDF for GH-PAGES
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/html/_pdf
+          cp -u _build/latex/*.pdf _build/html/_pdf
+      - name: Build Download Notebooks (sphinx-tojupyter)
+        shell: bash -l {0}
+        run: |
+          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
+          zip -r download-notebooks.zip _build/jupyter
+      - uses: actions/upload-artifact@v2
+        with:
+          name: download-notebooks
+          path: download-notebooks.zip
+      - name: Copy Download Notebooks for GH-PAGES
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/html/_notebooks
+          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      # Final Build of HTML (with assets)
+      - name: Build HTML
+        shell: bash -l {0}
+        run: |
+          jb build lectures --path-output ./ -n -W --keep-going
+      - name: Deploy website to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/html/
+          cname: jax.quantecon.org
+      - name: Prepare lecture-jax.notebooks sync
+        shell: bash -l {0}
+        run: |
+          mkdir -p _build/lecture-jax.notebooks
+          cp -a _notebook_repo/. _build/lecture-jax.notebooks
+          cp _build/jupyter/*.ipynb _build/lecture-jax.notebooks
+          ls -a _build/lecture-jax.notebooks
+      - name: Commit notebooks to lecture-jax.notebooks
+        shell: bash -l {0}
+        env:
+          QE_SERVICES_PAT: ${{ secrets.QUANTECON_SERVICES_PAT }}
+        run: |
+          git clone https://quantecon-services:$QE_SERVICES_PAT@github.com/quantecon/lecture-jax.notebooks
+
+          cp _build/lecture-jax.notebooks/*.ipynb lecture-jax.notebooks
+
+          cd jax.notebooks
+          git config user.name "QuantEcon Services"
+          git config user.email "admin@quantecon.org"
+          git add *.ipynb
+          git commit -m "auto publishing updates to notebooks"
+          git push origin master

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,13 @@
-name: quantecon
+name: lecture-jax
 channels:
   - default
 dependencies:
-  - python=3.9
+  - python=3.10
   - anaconda=2022.10
   - pip
   - pip:
     - jupyter-book==0.15.1
-    - quantecon-book-theme==0.4.1
+    - quantecon-book-theme==0.5.0
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1


### PR DESCRIPTION
This PR updates

- [x] GitHub actions workflows
- [x] updates to use the [latest quantecon docker container](https://hub.docker.com/layers/mmcky/quantecon-lecture-python/cuda-12.1.0-anaconda-2023-03-py310-b/images/sha256-3f8345f3e7ca43bbe51b10bff8359c977a490059fa7efc116ce479f856717dba?context=repo)

Will do these post merge:

- [ ] setup custom DNS in route53
- [ ] setup custom DNS in gh-pages