### PR TITLE
MAINT: Harmonise GPU admonition, remove backend checks + add nvidia-smi

### DIFF
--- a/lectures/aiyagari_jax.md
+++ b/lectures/aiyagari_jax.md
@@ -13,6 +13,15 @@ kernelspec:
 
 # The Aiyagari Model
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
 
 ## Overview
 
@@ -54,18 +63,6 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 ```
-
-
-Let’s check the backend used by JAX and the devices available.
-
-```{code-cell} ipython3
-# Check if JAX is using GPU
-print(f"JAX backend: {jax.devices()[0].platform}")
-
-# Check the devices available for JAX
-print(jax.devices())
-```
-
 
 We will use 64 bit floats with JAX in order to increase the precision.
 

--- a/lectures/arellano.md
+++ b/lectures/arellano.md
@@ -13,7 +13,15 @@ kernelspec:
 
 # Default Risk and Income Fluctuations
 
-+++
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
 
 In addition to what's in Anaconda, this lecture will need the following libraries:
 

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -23,6 +23,16 @@ kernelspec:
 
 # Inventory Dynamics
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
+
 ```{index} single: Markov process, inventory
 ```
 

--- a/lectures/jax_intro.md
+++ b/lectures/jax_intro.md
@@ -14,12 +14,14 @@ kernelspec:
 # JAX
 
 
-```{note}
-This lecture is built using [hardware](status:machine-details) that
-has access to a GPU. This means that 
+```{admonition} GPU
+:class: warning
 
-1. the lecture might be significantly slower when running on your machine, and
-2. the code is well-suited to execution with [Google colab](https://colab.research.google.com/github/QuantEcon/lecture-python-programming.notebooks/blob/master/jax_intro.ipynb)
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
 ```
 
 This lecture provides a short introduction to [Google JAX](https://github.com/google/jax).

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -29,6 +29,16 @@ kernelspec:
 :depth: 2
 ```
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
+
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3
@@ -61,17 +71,6 @@ import quantecon as qe
 import jax
 import jax.numpy as jnp
 from jax import random
-```
-
-
-Let’s check the backend used by JAX and the devices available
-
-```{code-cell} ipython3
-# Check if JAX is using GPU
-print(f"JAX backend: {jax.devices()[0].platform}")
-
-# Check the devices available for JAX
-print(jax.devices())
 ```
 
 

--- a/lectures/newtons_method.md
+++ b/lectures/newtons_method.md
@@ -14,6 +14,16 @@ kernelspec:
 
 # Newton’s Method via JAX
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
+
 ## Overview
 
 Continuing from the [Newton's Method lecture](https://python.quantecon.org/newton_method.html), we are going to solve the multidimensional problem with `JAX`.
@@ -26,16 +36,6 @@ We use the following imports in this lecture
 import jax
 import jax.numpy as jnp
 from scipy.optimize import root
-```
-
-Let’s check the backend used by JAX and the devices available.
-
-```{code-cell} ipython3
-# Check if JAX is using GPU
-print(f"JAX backend: {jax.devices()[0].platform}")
-
-# Check the devices available for JAX
-print(jax.devices())
 ```
 
 ## The Two Goods Market Equilibrium

--- a/lectures/opt_invest.md
+++ b/lectures/opt_invest.md
@@ -14,6 +14,16 @@ kernelspec:
 
 # Optimal Investment
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
+
 We require the following library to be installed.
 
 ```{code-cell} ipython3
@@ -26,7 +36,9 @@ We require the following library to be installed.
 A monopolist faces inverse demand
 curve
 
-$$    P_t = a_0 - a_1 Y_t + Z_t, $$
+$$
+P_t = a_0 - a_1 Y_t + Z_t,
+$$
 
 where
 
@@ -60,18 +72,6 @@ import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 ```
-
-
-Let’s check the backend used by JAX and the devices available
-
-```{code-cell} ipython3
-# Check if JAX is using GPU
-print(f"JAX backend: {jax.devices()[0].platform}")
-
-# Check the devices available for JAX
-print(jax.devices())
-```
-
 
 We will use 64 bit floats with JAX in order to increase the precision.
 

--- a/lectures/opt_savings.md
+++ b/lectures/opt_savings.md
@@ -13,6 +13,16 @@ kernelspec:
 
 # Optimal Savings
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
+
 In addition to what’s in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3

--- a/lectures/short_path.md
+++ b/lectures/short_path.md
@@ -15,6 +15,15 @@ kernelspec:
 
 # Shortest Paths
 
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
 
 ## Overview
 
@@ -27,19 +36,6 @@ import numpy as np
 import jax.numpy as jnp
 import jax
 ```
-
-
-
-Let’s check the backend used by JAX and the devices available.
-
-```{code-cell} ipython3
-# Check if JAX is using GPU
-print(f"JAX backend: {jax.devices()[0].platform}")
-
-# Check the devices available for JAX
-print(jax.devices())
-```
-
 
 ## Solving for Minimum Cost-to-Go
 

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -21,3 +21,11 @@ This table contains the latest execution statistics.
 These lectures are built on `linux` instances through `github actions`  and `amazon web services (aws)` to
 enable access to a `gpu`. These lectures are built on a [p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/)
 that has access to `8 vcpu's`, a `V100 NVIDIA Tesla GPU`, and `61 Gb` of memory.
+
+You can check the backend used by JAX using:
+
+```{code-cell} ipython3
+import jax
+# Check if JAX is using GPU
+print(f"JAX backend: {jax.devices()[0].platform}")
+```

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -40,14 +40,10 @@ from collections import namedtuple
 ```
 
 
-Let's check the backend used by JAX and the devices available
+Let's check the hardware we are running on:
 
 ```{code-cell} ipython3
-# Check if JAX is using GPU
-print(f"JAX backend: {jax.devices()[0].platform}")
-
-# Check the devices available for JAX
-print(jax.devices())
+!nvidia-smi
 ```
 
 

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -14,7 +14,19 @@ kernelspec:
 
 # Wealth Distribution Dynamics
 
-This lecture is the extended JAX implementation of [this lecture](https://python.quantecon.org/wealth_dynamics.html). Please refer that lecture for all background and notation.
+```{admonition} GPU
+:class: warning
+
+This lecture is accelerated via [hardware](status:machine-details) that has access to a GPU and JAX for GPU programming.
+
+Free GPUs are available on Google Colab. To use this option, please click on the play icon top right, select Colab, and set the runtime environment to include a GPU.
+
+Alternatively, if you have your own GPU, you can follow the [instructions](https://github.com/google/jax) for installing JAX with GPU support. If you would like to install JAX running on the `cpu` only you can use `pip install jax[cpu]`
+```
+
+This lecture is the extended JAX implementation of [this lecture](https://python.quantecon.org/wealth_dynamics.html). 
+
+Please refer that lecture for all background and notation.
 
 We will use the following imports.
 


### PR DESCRIPTION
This PR:

- [x] adds GPU admonition from https://manual.quantecon.org/styleguide/code.html#jax
- [x] removes code snippets for checking the gpu backend (and added to `status.md`)
- [x] add `nvidia-smi` to make hardware more visible to readers (testing in `wealth_dynamics` lecture)

cc: @jstac

- [x] review build in the morning before merging