### PR TITLE
MAINT: Standardise plot size and remove custom matplotlib requests

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -36,6 +36,9 @@ latex:
 sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinxcontrib.youtube, sphinx.ext.todo, sphinx_exercise, sphinx_togglebutton, sphinx_tojupyter]
   config:
+    # myst-nb config
+    nb_render_image_options:
+      width: 80%
     nb_mime_priority_overrides: [
       ['html', 'application/vnd.jupyter.widget-view+json', 10],
       ['html', 'application/javascript', 20],

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -47,9 +47,7 @@ This lecture explores JAX implementations of the exercises in the lecture on [in
 We will use the following imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import numpy as np
 import jax
 import jax.numpy as jnp

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -64,9 +64,7 @@ This lecture focuses on implementing the same computations in JAX.
 Let's start with some imports:
 
 ```{code-cell} ipython3
-%matplotlib inline
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import quantecon as qe
 import jax
 import jax.numpy as jnp

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -54,7 +54,6 @@ If your local environment is still not working you can do two things.
 First, you can use a remote machine instead, by clicking on the Launch Notebook icon available for each lecture
 
 ```{image} _static/lecture_specific/troubleshooting/launch.png
-
 ```
 
 Second, you can report an issue, so we can try to fix your local set up.

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -32,20 +32,16 @@ We will use the following imports.
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
-plt.rcParams["figure.figsize"] = (11, 5)  #set default figure size
 import jax
 import jax.numpy as jnp
 from collections import namedtuple
-%matplotlib inline
 ```
-
 
 Let's check the hardware we are running on:
 
 ```{code-cell} ipython3
 !nvidia-smi
 ```
-
 
 ## Lorenz Curves and the Gini Coefficient
 


### PR DESCRIPTION
This PR:

- [x] adds 80% width rule for plots and figures from code in `_config.yml`
- [x] removes matplotlib code to set fig size