### PR TITLE
MNT: Move lecture + remove for now

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -2,8 +2,7 @@ title: Quantitative Economics with Python using JAX
 author: Thomas J. Sargent & John Stachurski
 logo: _static/qe-logo-large.png
 description: This website presents a set of lectures on quantitative economic modeling, designed and written by Thomas J. Sargent and John Stachurski.
-# analytics:
-#   google_analytics_id: 
+only_build_toc_files: false
 
 parse:
   myst_enable_extensions:

--- a/lectures/_toc.yml
+++ b/lectures/_toc.yml
@@ -12,7 +12,6 @@ parts:
   numbered: true
   chapters:
   - file: inventory_dynamics
-  - file: inventory_ssd
   - file: kesten_processes
   - file: wealth_dynamics
 - caption: Data and Empirics
@@ -25,6 +24,7 @@ parts:
   - file: short_path
   - file: opt_invest
   - file: opt_savings
+  # - file: inventory_ssd
   - file: ifp_egm
   - file: arellano
   - file: aiyagari_jax


### PR DESCRIPTION
This PR

- [x] moves `inventory_ssd` to new section after `optimal savings`
- [x] removes from `_toc.yml` for now and https://github.com/QuantEcon/lecture-jax/issues/99 will document it's reinstatement