### PR TITLE
EH: Update theme for COLAB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     needs: deploy-runner
     runs-on: [self-hosted, cml-gpu]
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310-b
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.1.0-anaconda-2023-03-py310-d
       options: --gpus all
     steps:
       - uses: actions/checkout@v3

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - pip
   - pip:
     - jupyter-book==0.15.1
-    - quantecon-book-theme==0.5.0
+    - quantecon-book-theme==0.5.3
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
     - sphinx-exercise==0.4.1


### PR DESCRIPTION
This PR updates to `quantecon-book-theme==0.5.3` to enable colab as the default. 

- [x] check `search` isn't too big an issue once preview is built