### PR TITLE
FIX: use split instead of equation environment multline

### DIFF
--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -570,18 +570,18 @@ Modifying [](eq:neweqn101) to accommodate the new growth specifications,
 we find that $v$ satisfies
 
 $$
-\begin{split}
-    v(X_t) = \beta \times \\
-        {\mathbb E}_t
-        \left\{
-            \exp[
+\begin{aligned}
+    v(X_t) = & \beta \times \\
+             & {\mathbb E}_t
+                \left\{
+                \exp[
                 a + (1-\gamma) Z_t +
                     \bar \sigma \exp(H^d_t) \epsilon_{d, t+1} -
                     \gamma \bar \sigma \exp(H^c_t) \epsilon_{c, t+1}
                 ]
-            (1 + v(X_{t+1}))
-        \right\}
-\end{split}
+                (1 + v(X_{t+1}))
+                \right\}
+\end{aligned}
 $$ (eq:neweqn102)
 
 where, as before, $a := \mu_d - \gamma \mu_c$

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -570,7 +570,7 @@ Modifying [](eq:neweqn101) to accommodate the new growth specifications,
 we find that $v$ satisfies
 
 $$
-\begin{multline}
+\begin{split}
     v(X_t) = \beta \times \\
         {\mathbb E}_t
         \left\{
@@ -581,7 +581,7 @@ $$
                 ]
             (1 + v(X_{t+1}))
         \right\}
-\end{multline}
+\end{split}
 $$ (eq:neweqn102)
 
 where, as before, $a := \mu_d - \gamma \mu_c$

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -617,16 +617,16 @@ expectations of lognormals to obtain
 Let
 
 $$
-\begin{multline}
-    A(h_c, h_d, z, h_c', h_d', z') := \\
-            \beta \,
+\begin{aligned}
+    A(h_c, h_d, z, h_c', h_d', z') := & \\
+            & \beta \,
                 \exp
                 \left[
                     a + (1-\gamma) z +
                     \bar \sigma^2 \frac{\exp(2 h_d) + \gamma^2 \exp(2 h_c)}{2}
                 \right]
         P(h_c, h_c')Q(h_d, h_d')R(z, z')
-\end{multline}
+\end{aligned}
 $$
 
 where $P, Q, R$ are the stochastic matrices for, respectively, discretized


### PR DESCRIPTION
This PR fixes `latex` builds

fixes #116 