### PR TITLE
MAINT: check gpu admonitions and tidy up

### DIFF
--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -27,10 +27,6 @@ kernelspec:
 ```{index} single: Markov process, inventory
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture explores JAX implementations of the exercises in the lecture on [inventory dynamics](https://python.quantecon.org/inventory_dynamics.html).

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -24,10 +24,6 @@ kernelspec:
 ```{index} single: Linear State Space Models
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{include} _admonition/gpu.md
 ```
 

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -13,6 +13,8 @@ kernelspec:
 
 # An Asset Pricing Problem
 
+```{include} _admonition/gpu.md
+```
 
 ## Overview
 

--- a/lectures/mle.md
+++ b/lectures/mle.md
@@ -13,10 +13,6 @@ kernelspec:
 
 # Maximum Likelihood Estimation
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{include} _admonition/gpu.md
 ```
 


### PR DESCRIPTION
This PR checks all lectures for the `gpu` admonition `include` directive and tidies up some `content` directives that are not required. 