### PR TITLE
MAINT: Use np.interp as supported by numba

### DIFF
--- a/lectures/cake_eating_numerical.md
+++ b/lectures/cake_eating_numerical.md
@@ -25,7 +25,7 @@ In addition to what's in Anaconda, this lecture will need the following librarie
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install interpolation quantecon
+!pip install quantecon
 ```
 
 We will use the following imports.
@@ -324,7 +324,6 @@ for the purpose of comparing the results of JAX implementation.
 ```{code-cell} ipython3
 import numpy as np
 from numba import prange, njit
-from interpolation import interp
 from quantecon.optimize import brent_max
 ```
 
@@ -360,7 +359,7 @@ def state_action_value_numba(c, x, v_array, cem):
     * v_array: value function array guess, 1-D array
     * cem: Cake Eating Numba Model instance
     """
-    return u_numba(c, cem) + cem.β * interp(cem.x_grid, v_array, x - c)
+    return u_numba(c, cem) + cem.β * np.interp(x - c, cem.x_grid, v_array)
 ```
 
 ```{code-cell} ipython3

--- a/lectures/ifp_egm.md
+++ b/lectures/ifp_egm.md
@@ -33,7 +33,7 @@ We will use the following libraries and imports.
 ```{code-cell} ipython3
 :tags: [hide-output]
 
-!pip install --upgrade quantecon interpolation
+!pip install --upgrade quantecon
 ```
 
 ```{code-cell} ipython3
@@ -43,7 +43,6 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 
-from interpolation import interp
 from numba import njit, float64
 from numba.experimental import jitclass
 ```
@@ -483,7 +482,7 @@ def K_egm_nb(a_in, σ_in, ifp):
     
     # Linear interpolation of policy using endogenous grid
     def σ(a, z):
-        return interp(a_in[:, z], σ_in[:, z], a)
+        return np.interp(a, a_in[:, z], σ_in[:, z])
     
     # Allocate memory for new consumption array
     σ_out = np.zeros_like(σ_in)


### PR DESCRIPTION
This PR switches from `interpolation` package to use `np.interp` as this is now supported directly by `numba`

https://numba.pydata.org/numba-doc/dev/developer/autogen_numpy_listing.html#numpy.interp

ref: https://github.com/QuantEcon/QuantEcon.py/issues/722 and https://github.com/QuantEcon/QuantEcon.py/pull/724