### PR TITLE
Fix incorrect path warning in CI

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -81,8 +81,8 @@ sphinx:
       twitter: quantecon
       twitter_logo_url: https://assets.quantecon.org/img/qe-twitter-logo.png
       og_logo_url: https://assets.quantecon.org/img/qe-og-logo.png
-      description: This website presents a set of lectures on quantitative economic modeling, designed and written by Thomas J. Sargent and John Stachurski.
-      keywords: Python, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
+      description: This website presents a set of lectures on quantitative economic modeling using JAX, designed and written by Thomas J. Sargent and John Stachurski.
+      keywords: Python, JAX, QuantEcon, Quantitative Economics, Economics, Sloan, Alfred P. Sloan Foundation, Tom J. Sargent, John Stachurski
       analytics:
         google_analytics_id: G-K1NYBSC1CZ
       launch_buttons:
@@ -95,7 +95,7 @@ sphinx:
     mathjax_path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
     rediraffe_redirects:
       index_toc.md: intro.md
-    tojupyter_static_file_path: ["source/_static", "_static"]
+    tojupyter_static_file_path: ["_static"]
     tojupyter_target_html: true
     tojupyter_urlpath: "https://jax.quantecon.org/"
     tojupyter_image_urlpath: "https://jax.quantecon.org/_static/"


### PR DESCRIPTION
This PR fixes the following warning that comes from CI:
```
WARNING: tojupyter_static_path entry /__w/lecture-jax/lecture-jax/lectures/source/_static does not exist
```

See https://github.com/QuantEcon/lecture-jax/actions/runs/8555440893/job/23442936380?pr=173#step:9:112 for reference.

Also, adds `JAX` as keywords in config.