### PR TITLE
MAINT: use Github based GPU instance

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -4,30 +4,10 @@ on:
     branches:
       - main
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v2
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   cache:
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
+    runs-on: ubuntu-latest-gpu
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-02-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,26 +24,26 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v3
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
-      # - name: Build Download Notebooks (sphinx-tojupyter)
-      #   shell: bash -l {0}
-      #   run: |
-      #     jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
-      #     mkdir -p _build/html/_notebooks
-      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
-      # - name: Build PDF from LaTeX
-      #   shell: bash -l {0}
-      #   run: |
-      #     jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
-      #     mkdir _build/html/_pdf
-      #     cp -u _build/latex/*.pdf _build/html/_pdf
+      - name: Build Download Notebooks (sphinx-tojupyter)
+        shell: bash -l {0}
+        run: |
+          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
+          mkdir -p _build/html/_notebooks
+          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      - name: Build PDF from LaTeX
+        shell: bash -l {0}
+        run: |
+          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
+          mkdir _build/html/_pdf
+          cp -u _build/latex/*.pdf _build/html/_pdf
       # Final Build of HTML
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Upgrade Nvidia Driver
         shell: bash -l {0}
-        run: sudo apt-get install -y cuda-drivers
+        run: sudo apt-get update && sudo apt-get install -y cuda-drivers
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v3
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,12 @@ jobs:
   preview:
     runs-on: ubuntu-latest-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-02-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Upgrade Nvidia Driver
-        shell: bash -l {0}
-        run: sudo apt-get update && sudo apt-get install -y cuda-drivers
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install numpyro[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install numpyro[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-          pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+          pip install --upgrade "jax[cuda12_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Upgrade Nvidia Driver
+        shell: bash -l {0}
+        run: sudo apt-get install -y cuda-drivers
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build Project [using jupyter-book]
+name: Build Preview [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ jobs:
           python-version: "3.11"
           environment-file: environment.yml
           activate-environment: quantecon
-      - name: Install JAX[CUDA]
+      - name: Install JAX[CUDA] and Numpyro[CUDA]
         shell: bash -l {0}
         run: |
+          pip install numpyro[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}
@@ -42,18 +43,18 @@ jobs:
       #     name: build-cache
       #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
-      - name: Build Download Notebooks (sphinx-tojupyter)
-        shell: bash -l {0}
-        run: |
-          jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
-          mkdir -p _build/html/_notebooks
-          cp -u _build/jupyter/*.ipynb _build/html/_notebooks
-      - name: Build PDF from LaTeX
-        shell: bash -l {0}
-        run: |
-          jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
-          mkdir _build/html/_pdf
-          cp -u _build/latex/*.pdf _build/html/_pdf
+      # - name: Build Download Notebooks (sphinx-tojupyter)
+      #   shell: bash -l {0}
+      #   run: |
+      #     jb build lectures --path-output ./ --builder=custom --custom-builder=jupyter -n -W --keep-going
+      #     mkdir -p _build/html/_notebooks
+      #     cp -u _build/jupyter/*.ipynb _build/html/_notebooks
+      # - name: Build PDF from LaTeX
+      #   shell: bash -l {0}
+      #   run: |
+      #     jb build lectures --builder pdflatex --path-output ./ -n -W --keep-going
+      #     mkdir _build/html/_pdf
+      #     cp -u _build/latex/*.pdf _build/html/_pdf
       # Final Build of HTML
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,23 @@ on: [pull_request]
 jobs:
   preview:
     runs-on: ubuntu-latest-gpu
-    container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
-      options: --gpus all
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Setup Anaconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          auto-activate-base: true
+          miniconda-version: 'latest'
+          python-version: "3.11"
+          environment-file: environment.yml
+          activate-environment: quantecon
+      - name: Install JAX[CUDA]
+        shell: bash -l {0}
+        run: |
+          pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,8 @@
 name: Build Project [using jupyter-book]
 on: [pull_request]
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v2
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   preview:
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
+    runs-on: ubuntu-latest-gpu
     container:
       image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
       options: --gpus all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,25 +4,12 @@ jobs:
   preview:
     runs-on: ubuntu-latest-gpu
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.3.1-anaconda-2024-02-py311
       options: --gpus all
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      # - name: Setup Anaconda
-      #   uses: conda-incubator/setup-miniconda@v3
-      #   with:
-      #     auto-update-conda: true
-      #     auto-activate-base: true
-      #     miniconda-version: 'latest'
-      #     python-version: "3.11"
-      #     environment-file: environment.yml
-      #     activate-environment: quantecon
-      # - name: Install JAX[CUDA] and Numpyro[CUDA]
-      #   shell: bash -l {0}
-      #   run: |
-      #     pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,23 +3,26 @@ on: [pull_request]
 jobs:
   preview:
     runs-on: ubuntu-latest-gpu
+    container:
+      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      options: --gpus all
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Anaconda
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          auto-update-conda: true
-          auto-activate-base: true
-          miniconda-version: 'latest'
-          python-version: "3.11"
-          environment-file: environment.yml
-          activate-environment: quantecon
-      - name: Install JAX[CUDA] and Numpyro[CUDA]
-        shell: bash -l {0}
-        run: |
-          pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+      # - name: Setup Anaconda
+      #   uses: conda-incubator/setup-miniconda@v3
+      #   with:
+      #     auto-update-conda: true
+      #     auto-activate-base: true
+      #     miniconda-version: 'latest'
+      #     python-version: "3.11"
+      #     environment-file: environment.yml
+      #     activate-environment: quantecon
+      # - name: Install JAX[CUDA] and Numpyro[CUDA]
+      #   shell: bash -l {0}
+      #   run: |
+      #     pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       - name: Install JAX[CUDA] and Numpyro[CUDA]
         shell: bash -l {0}
         run: |
-          pip install numpyro[cuda] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
           pip install --upgrade "jax[cuda12_local]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
       - name: Check nvidia drivers
         shell: bash -l {0}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,31 +4,11 @@ on:
     tags:
       - 'publish*'
 jobs:
-  deploy-runner:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: iterative/setup-cml@v2
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Deploy runner on EC2
-        env:
-          REPO_TOKEN: ${{ secrets.QUANTECON_SERVICES_PAT }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          cml runner launch \
-              --cloud=aws \
-              --cloud-region=us-west-2 \
-              --cloud-type=p3.2xlarge \
-              --labels=cml-gpu \
-              --cloud-hdd-size=40
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: deploy-runner
-    runs-on: [self-hosted, cml-gpu]
+    runs-on: ubuntu-latest-gpu
     container:
-      image: docker://mmcky/quantecon-lecture-python:cuda-12.3.1-anaconda-2024-02-py311
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.5.0-anaconda-2024-02-py311
       options: --gpus all
     steps:
       - name: Checkout
@@ -46,7 +26,7 @@ jobs:
         run: pip list
       # Download Build Cache from cache.yml
       - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v3
         with:
           workflow: cache.yml
           branch: main

--- a/environment.yml
+++ b/environment.yml
@@ -1,27 +1,26 @@
-name: lecture-jax
+name: quantecon
 channels:
   - default
 dependencies:
   - python=3.11
-  - anaconda=2023.09
+  - anaconda=2024.02
   - pip
   - pip:
     - jupyter-book==0.15.1
-    - docutils==0.17.1
     - quantecon-book-theme==0.7.1
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
+    - sphinx-reredirects==0.1.3
     - sphinx-exercise==0.4.1
     - ghp-import==1.1.0
     - sphinxcontrib-youtube==1.1.0
     - sphinx-togglebutton==0.3.1
-    - arviz==0.13.0
+    - array-to-latex
+    - prettytable
     - kaleido
-    # Sandpit Requirements
-    # - quantecon
-    # - array-to-latex
-    # - PuLP
-    # - cvxpy
-    # - cvxopt
-    # - cylp
-    # - prettytable
+    - arviz
+    # Docker Requirements
+    - pytz
+    # Docutils Issue (https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322)
+    - docutils==0.17.1
+

--- a/lectures/status.md
+++ b/lectures/status.md
@@ -18,9 +18,8 @@ This table contains the latest execution statistics.
 
 (status:machine-details)=
 
-These lectures are built on `linux` instances through `github actions`  and `amazon web services (aws)` to
-enable access to a `gpu`. These lectures are built on a [p3.2xlarge](https://aws.amazon.com/ec2/instance-types/p3/)
-that has access to `8 vcpu's`, a `V100 NVIDIA Tesla GPU`, and `61 Gb` of memory.
+These lectures are built on `linux` instances through `github actions` that has 
+access to a `gpu`. These lectures make use of the nvidia `T4` card.
 
 You can check the backend used by JAX using:
 


### PR DESCRIPTION
This PR makes use of the `Tesla T4` instance now available on `GitHub Actions` as a beta instance. 

- [x] uses `github actions` supplied instances
- [x] deploys from github containers for our docker environment to speed up builds

this migrates

- [x] `ci`
- [x] `publish`
- [x] `cache`

to run on GitHub actions. 