### PR TITLE
MAINT: remove %matplotlib inline and contents directive

### DIFF
--- a/lectures/lucas_model.md
+++ b/lectures/lucas_model.md
@@ -29,13 +29,6 @@ kernelspec:
 ```{index} single: Models; Lucas Asset Pricing
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
-
-
-
 ## Overview
 
 An asset is a claim on a stream of prospective payments.

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment


### PR DESCRIPTION
This PR removes `contents` directives to simplify