### PR TITLE
MAINT: rename gpu runner for QuantEcon

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   cache:
-    runs-on: quantecon-gpu-runner
+    runs-on: quantecon-gpu
     container:
       image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312
       options: --gpus all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Preview [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: quantecon-gpu-runner
+    runs-on: quantecon-gpu
     container:
       image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312
       options: --gpus all

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -2,7 +2,7 @@ name: Build Project on Google Collab (Execution)
 on: [pull_request]
 jobs:
   execution-checks:
-    runs-on: quantecon-gpu-runner
+    runs-on: quantecon-gpu
     container:
       image: docker://us-docker.pkg.dev/colab-images/public/runtime
       options: --gpus all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: quantecon-gpu-runner
+    runs-on: quantecon-gpu
     container:
       image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312
       options: --gpus all


### PR DESCRIPTION
This is a minor maintenance PR to update the name of the `quantecon-gpu` runner on GitHub