### PR TITLE
MAINT: upgrade to jupyter-book==1.0.3

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -3,11 +3,14 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # run cache monthly to prevent expiration
+    - cron:  '0 0 1 * *'
 jobs:
   cache:
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      # - name: Download "build" folder (cache)
-      #   uses: dawidd6/action-download-artifact@v3
-      #   with:
-      #     workflow: cache.yml
-      #     branch: main
-      #     name: build-cache
-      #     path: _build
+      - name: Download "build" folder (cache)
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: cache.yml
+          branch: main
+          name: build-cache
+          path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,13 @@ jobs:
       - name: Display Pip Versions
         shell: bash -l {0}
         run: pip list
-      - name: Download "build" folder (cache)
-        uses: dawidd6/action-download-artifact@v3
-        with:
-          workflow: cache.yml
-          branch: main
-          name: build-cache
-          path: _build
+      # - name: Download "build" folder (cache)
+      #   uses: dawidd6/action-download-artifact@v3
+      #   with:
+      #     workflow: cache.yml
+      #     branch: main
+      #     name: build-cache
+      #     path: _build
       # Build Assets (Download Notebooks and PDF via LaTeX)
       - name: Build Download Notebooks (sphinx-tojupyter)
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   preview:
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312-b
       options: --gpus all
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: quantecon-gpu
     container:
-      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312
+      image: ghcr.io/quantecon/lecture-python-container:cuda-12.6.0-anaconda-2024-10-py312-b
       options: --gpus all
     steps:
       - name: Checkout

--- a/environment.yml
+++ b/environment.yml
@@ -6,21 +6,17 @@ dependencies:
   - anaconda=2024.10
   - pip
   - pip:
-    - jupyter-book==0.15.1
-    - quantecon-book-theme==0.7.2
+    - jupyter-book==1.0.3
+    - quantecon-book-theme==0.7.6
     - sphinx-tojupyter==0.3.0
     - sphinxext-rediraffe==0.2.7
-    - sphinx-reredirects==0.1.3
-    - sphinx-exercise==0.4.1
+    - sphinx-reredirects==0.1.4
+    - sphinx-exercise==1.0.1
+    - sphinx-proof==0.2.0
     - ghp-import==1.1.0
-    - sphinxcontrib-youtube==1.1.0
-    - sphinx-togglebutton==0.3.1
-    - array-to-latex
-    - prettytable
-    - kaleido
-    - arviz
+    - sphinxcontrib-youtube==1.3.0 #Version 1.3.0 is required as quantecon-book-theme is only compatible with sphinx<=5
+    - sphinx-togglebutton==0.3.2
+    - kaleido # generating static images support
     # Docker Requirements
     - pytz
-    # Docutils Issue (https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/322)
-    - docutils==0.17.1
 


### PR DESCRIPTION
This PR

- [x] upgrades to use `jupyter-book==1.0.3` and associated packages
- [x] full execution test run
- [x] re-enable build cache
- [x] enables monthly scheduled run of the build cache. 