### PR TITLE
FIX: jax_intro timeout - use lax.fori_loop instead of Python for loop

### DIFF
--- a/lectures/jax_intro.md
+++ b/lectures/jax_intro.md
@@ -727,14 +727,29 @@ def compute_call_price_jax(β=β,
 
     s = jnp.full(M, np.log(S0))
     h = jnp.full(M, h0)
-    for t in range(n):
+
+    def update(i, loop_state):
+        s, h, key = loop_state
         key, subkey = jax.random.split(key)
         Z = jax.random.normal(subkey, (2, M))
         s = s + μ + jnp.exp(h) * Z[0, :]
         h = ρ * h + ν * Z[1, :]
+        new_loop_state = s, h, key
+        return new_loop_state
+
+    initial_loop_state = s, h, key
+    final_loop_state = jax.lax.fori_loop(0, n, update, initial_loop_state)
+    s, h, key = final_loop_state
+
     expectation = jnp.mean(jnp.maximum(jnp.exp(s) - K, 0))
         
     return β**n * expectation
+```
+
+```{note}
+We use `jax.lax.fori_loop` instead of a Python `for` loop.
+This allows JAX to compile the loop efficiently without unrolling it,
+which significantly reduces compilation time for large arrays.
 ```
 
 Let's run it once to compile it:


### PR DESCRIPTION
## Problem

The `compute_call_price_jax` function in `jax_intro.md` was timing out during builds (600s cell execution timeout).

## Root Cause

JAX unrolls Python `for` loops during JIT compilation. With large arrays (`M=10,000,000`), this causes excessive compilation time as JAX traces through each iteration separately.

## Solution

Replace the Python `for` loop with `jax.lax.fori_loop`, which compiles the loop efficiently without unrolling:

```python
# Before (Python for loop - gets unrolled)
for t in range(n):
    key, subkey = jax.random.split(key)
    Z = jax.random.normal(subkey, (2, M))
    s = s + μ + jnp.exp(h) * Z[0, :]
    h = ρ * h + ν * Z[1, :]

# After (JAX fori_loop - compiled efficiently)
def update(i, state):
    s, h, key = state
    key, subkey = jax.random.split(key)
    Z = jax.random.normal(subkey, (2, M))
    s = s + μ + jnp.exp(h) * Z[0, :]
    h = ρ * h + ν * Z[1, :]
    return s, h, key

s, h, key = jax.lax.fori_loop(0, n, update, (s, h, key))
```

Added an explanatory note for students about why we use `fori_loop`.

## Related

This is the same fix as QuantEcon/lecture-python-programming.myst#442