### PR TITLE
MAINT: Update to latest AMI with CUDA 13

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,5 +1,6 @@
 images:
-  quantecon-ubuntu24:
+  quantecon_ubuntu2404:
     platform: "linux"
     arch: "x64"
-    ami: "ami-09baf66e396fa7cfd"
+    ami: "ami-0edec81935264b6d3"
+    region: "us-west-2"

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon-ubuntu24/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Preview [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon-ubuntu24/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon-ubuntu24/disk=large"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/disk=large"
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

- Update `runs-on.yml` to use the latest AMI (`ami-0edec81935264b6d3`) with CUDA 13
- Rename image from `quantecon-ubuntu24` to `quantecon_ubuntu2404`
- Add `region: us-west-2` specification
- Update all workflow files (`cache.yml`, `ci.yml`, `publish.yml`) to reference the new image name

## Reference

Matches the configuration used in lecture-python.myst:
https://github.com/QuantEcon/lecture-python.myst/blob/main/.github/runs-on.yml