### PR TITLE
Add fetch-depth: 0 to checkout for git header feature

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Setup Anaconda
         uses: conda-incubator/setup-miniconda@v3
         with:


### PR DESCRIPTION
## Changes

Adds `fetch-depth: 0` to the checkout steps in all workflow files (`ci.yml`, `cache.yml`, `publish.yml`).

This enables full git history to be fetched, which is required for the git header feature in quantecon-book-theme to display last modified dates on lecture pages.

## Reference

Matches the configuration used in lecture-python.myst:
https://github.com/QuantEcon/lecture-python.myst/blob/main/.github/workflows/ci.yml