### PR TITLE
MAINT: Add nb_merge_streams config option

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -36,6 +36,8 @@ sphinx:
   extra_extensions: [sphinx_multitoc_numbering, sphinxext.rediraffe, sphinxcontrib.youtube, sphinx.ext.todo, sphinx_exercise, sphinx_togglebutton, sphinx_tojupyter]
   config:
     bibtex_reference_style: author_year
+    suppress_warnings: ["mystnb.unknown_mime_type"]
+    nb_merge_streams: true
     # myst-nb config
     nb_render_image_options:
       width: 80%


### PR DESCRIPTION
## Changes

Adds two configuration options to `_config.yml`:

1. `nb_merge_streams: true` - Merges stdout/stderr streams in notebook output for cleaner display
2. `suppress_warnings: ["mystnb.unknown_mime_type"]` - Suppresses warnings about unknown MIME types

## Reference

Matches the configuration used in lecture-python.myst:
https://github.com/QuantEcon/lecture-python.myst/blob/main/lectures/_config.yml