### PR TITLE
Simplify Optax training functions with lax.fori_loop

### DIFF
--- a/lectures/jax_nn.md
+++ b/lectures/jax_nn.md
@@ -546,7 +546,7 @@ Let’s try running it.
 θ = initialize_params(param_key, config)
 
 # Warmup run to trigger JIT compilation
-θ_warmup = train_jax_optax(θ, x, y)
+train_jax_optax(θ, x, y)
 
 # Reset and time the actual run
 θ = initialize_params(param_key, config)


### PR DESCRIPTION
## Summary
- Replaced `lax.scan` with `lax.fori_loop` in `train_jax_optax` and `train_jax_optax_adam` functions
- These functions don't accumulate results, making `fori_loop` a more appropriate and simpler choice

## Changes
- Updated `train_step` function signature from `(carry, _)` to `(i, carry)`
- Removed unused return value `None` from the tuple
- Simplified the loop call by using `fori_loop` instead of `scan`
- Updated docstrings to reflect the use of `fori_loop`

## Benefits
- Clearer, more readable code
- More intuitive iteration pattern for simple loops without accumulation
- Consistent with JAX best practices (use `fori_loop` when you don't need `scan`'s accumulation feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)