### PR TITLE
Refactor jax_nn.md to use LayerParams NamedTuple

### DIFF
--- a/lectures/jax_nn.md
+++ b/lectures/jax_nn.md
@@ -761,14 +761,15 @@ def initialize_deep_params(
     return initialize_network(key, config_deep)
 
 θ_deep = initialize_deep_params(param_key)
+config_deep = Config(layer_sizes=(1, 6, 6, 6, 6, 6, 1))
 
 # Warmup
-train_jax_optax_adam(θ_deep, x, y)
+train_jax_optax_adam(θ_deep, x, y, config_deep)
 
 # Actual run
 θ_deep = initialize_deep_params(param_key)
 start_time = time()
-θ_deep = train_jax_optax_adam(θ_deep, x, y)
+θ_deep = train_jax_optax_adam(θ_deep, x, y, config_deep)
 θ_deep[0].W.block_until_ready()
 deep_runtime = time() - start_time
 
@@ -792,10 +793,10 @@ def train_deep_with_schedule(
         θ: list,
         x: jnp.ndarray,
         y: jnp.ndarray,
-        epochs: int = 4000
+        config: Config
     ):
     " Train deeper network with learning rate schedule. "
-
+    epochs = config.epochs
     schedule = optax.exponential_decay(
         init_value=0.003,
         transition_steps=1000,
@@ -817,12 +818,12 @@ def train_deep_with_schedule(
     return θ_final
 
 # Warmup
-train_deep_with_schedule(θ_deep, x, y)
+train_deep_with_schedule(θ_deep, x, y, config_deep)
 
 # Actual run
 θ_deep = initialize_deep_params(param_key)
 start_time = time()
-θ_deep_schedule = train_deep_with_schedule(θ_deep, x, y)
+θ_deep_schedule = train_deep_with_schedule(θ_deep, x, y, config_deep)
 θ_deep_schedule[0].W.block_until_ready()
 deep_schedule_runtime = time() - start_time
 
@@ -845,10 +846,11 @@ def train_with_elu(
         θ: list,
         x: jnp.ndarray,
         y: jnp.ndarray,
-        epochs: int = 4000,
-        learning_rate: float = 0.001
+        config: Config
     ):
     " Train model using ELU activation and Optax ADAM optimizer. "
+    epochs = config.epochs
+    learning_rate = config.learning_rate
 
     # Modified forward pass with ELU
     @jax.jit
@@ -881,12 +883,12 @@ def train_with_elu(
     return θ_final, f_elu, loss_fn_elu
 
 # Warmup run
-θ_elu, f_elu, loss_fn_elu = train_with_elu(θ, x, y)
+θ_elu, f_elu, loss_fn_elu = train_with_elu(θ, x, y, config)
 
 # Actual run
 θ = initialize_network(param_key, config)
 start_time = time()
-θ_elu, f_elu, loss_fn_elu = train_with_elu(θ, x, y)
+θ_elu, f_elu, loss_fn_elu = train_with_elu(θ, x, y, config)
 θ_elu[0].W.block_until_ready()
 elu_runtime = time() - start_time
 
@@ -909,10 +911,11 @@ def train_with_selu(
         θ: list,
         x: jnp.ndarray,
         y: jnp.ndarray,
-        epochs: int = 4000,
-        learning_rate: float = 0.001
+        config: Config
     ):
     " Train model using SELU activation and Optax ADAM optimizer. "
+    epochs = config.epochs
+    learning_rate = config.learning_rate
 
     # Modified forward pass with SELU
     @jax.jit
@@ -945,12 +948,12 @@ def train_with_selu(
     return θ_final, f_selu, loss_fn_selu
 
 # Warmup run
-θ_selu, f_selu, loss_fn_selu = train_with_selu(θ, x, y)
+θ_selu, f_selu, loss_fn_selu = train_with_selu(θ, x, y, config)
 
 # Actual run
 θ = initialize_network(param_key, config)
 start_time = time()
-θ_selu, f_selu, loss_fn_selu = train_with_selu(θ, x, y)
+θ_selu, f_selu, loss_fn_selu = train_with_selu(θ, x, y, config)
 θ_selu[0].W.block_until_ready()
 selu_runtime = time() - start_time
 


### PR DESCRIPTION
## Summary

This PR refactors the neural network implementation in `jax_nn.md` to use a cleaner, more structured approach for storing layer parameters, making it consistent with the pattern used in `ifp_dl.md`.

## Key Changes

### 1. **Introduced LayerParams NamedTuple**
- Added `LayerParams` class to store weights (W) and biases (b) for each network layer
- Provides better type safety and code readability compared to dict-based storage

### 2. **New Initialization Functions**
- **`initialize_layer()`**: Initializes a single layer using He initialization for weights and ones for biases
- **`initialize_network()`**: Replaces `initialize_params()`, builds entire network by stacking LayerParams
- Updated function signatures with type hints and inline comments for better documentation

### 3. **Updated Config**
- Added `layer_sizes: tuple = (1, 10, 10, 10, 1)` parameter to Config
- Removed `data_size` from Config (moved to `generate_data()` parameter)

### 4. **Consistent LayerParams Usage**
- Updated all forward pass functions (`f()`, `f_elu()`, `f_selu()`) to use LayerParams attributes
- Changed dict access patterns: `layer['W']` → `layer.W`, `layer['b']` → `layer.b`
- Updated all `block_until_ready()` calls to use attribute access

### 5. **Refactored Helper Functions**
- `initialize_deep_params()` now uses `initialize_network()` internally
- `generate_data()` simplified to not require config parameter

## Testing

✅ Converted to Python using jupytext and successfully ran all sections:
- Keras training
- JAX manual gradient descent
- JAX with Optax (SGD and ADAM)
- All optimization strategies (deeper networks, LR schedules, ELU/SELU activations)

All tests pass with expected MSE values, confirming the refactoring maintains the same network behavior and performance.

## Benefits

- **Better code organization**: Clearer structure for layer parameters
- **Type safety**: NamedTuple provides better type checking
- **Consistency**: Matches the pattern used in `ifp_dl.md`
- **Maintainability**: More explicit code with type hints and inline comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)