### PR TITLE
Fix errors and modernize keras and jax_nn lectures

### DIFF
--- a/lectures/jax_nn.md
+++ b/lectures/jax_nn.md
@@ -61,16 +61,6 @@ from functools import partial
 os.environ['KERAS_BACKEND'] = 'jax'
 ```
 
-```{note}
-Without setting the backend to JAX, the imports below might fail.
-
-If you have problems running the next cell in Jupyter, try 
-
-1. quitting
-2. running `export KERAS_BACKEND="jax"` 
-3. starting Jupyter on the command line from the same terminal.
-```
-
 ```{code-cell} ipython3
 import keras
 from keras import Sequential
@@ -194,7 +184,7 @@ def train_keras_model(
         y_validate,     # Validation data, outputs
         config: Config  # contains configuration data
     ):
-    print(f"Training NN using Keras.")
+    print("Training NN using Keras.")
     start_time = time()
     training_history = model.fit(
         x, y,
@@ -209,10 +199,10 @@ def train_keras_model(
     return model, training_history, elapsed, mse
 ```
 
-The next function extracts and visualizes a prediction from the trained model.
+The next function extracts and visualizes a prediction from the trained Keras model.
 
 ```{code-cell} ipython3
-def plot_keras_output(model, x, y, x_validate, y_validate):
+def plot_keras_output(model, x_validate, y_validate):
     y_predict = model.predict(x_validate, verbose=2)
     fig, ax = plt.subplots()
     ax.scatter(x_validate, y_validate, color='red', alpha=0.5)
@@ -230,7 +220,7 @@ model = build_keras_model(config)
 model, training_history, keras_runtime, keras_mse = train_keras_model(
     model, x_train, y_train, x_validate, y_validate, config
 )
-plot_keras_output(model, x_train, y_train, x_validate, y_validate)
+plot_keras_output(model, x_validate, y_validate)
 ```
 
 The fit is good and we note the relatively low final MSE.
@@ -281,8 +271,8 @@ class LayerParams(NamedTuple):
     Stores parameters for one layer of the neural network.
 
     """
-    W: jnp.ndarray     # weights
-    b: jnp.ndarray     # biases
+    W: jax.Array     # weights
+    b: jax.Array     # biases
 ```
 
 The following function initializes a single layer of the network using He
@@ -291,7 +281,7 @@ initialization for weights and ones for biases.
 ```{code-cell} ipython3
 def initialize_layer(in_dim, out_dim, key):
     """
-    Initialize weights and biases for a single layer of a the network.
+    Initialize weights and biases for a single layer of the network.
     Use He initialization for weights and ones for biases.
 
     """
@@ -341,7 +331,7 @@ Here’s our implementation of the ANN $f$:
 ```{code-cell} ipython3
 def f(
         θ: list,                        # Network parameters (pytree)
-        x: jnp.ndarray,                 # Input data (row vector)
+        x: jax.Array,                 # Input data (row vector)
         σ: callable = jnp.tanh          # Activation function
     ):
     """
@@ -356,23 +346,36 @@ def f(
 
 The function $ f $ is appropriately vectorized, so that we can pass in the entire
 set of input observations as `x` and return the predicted vector of outputs `y_hat = f(θ, x)`
-corresponding  to each data point.
+corresponding to each data point.
 
 The loss function is mean squared error, the same as the Keras case.
 
 ```{code-cell} ipython3
 def loss_fn(
         θ: list,            # Network parameters (pytree)
-        x: jnp.ndarray,     # Input data
-        y: jnp.ndarray      # Target data
+        x: jax.Array,     # Input data
+        y: jax.Array      # Target data
     ):
     return jnp.mean((f(θ, x) - y)**2)
 ```
 
-We’ll use its gradient to do stochastic gradient descent.
+We’ll also define a function to visualize predictions from our JAX models.
+
+```{code-cell} ipython3
+def plot_jax_output(θ, x_validate, y_validate):
+    fig, ax = plt.subplots()
+    ax.scatter(x_validate, y_validate, color=’red’, alpha=0.5)
+    ax.plot(x_validate.flatten(), f(θ, x_validate).flatten(),
+            label="fitted model", color=’black’)
+    ax.set_xlabel(‘x’)
+    ax.set_ylabel(‘y’)
+    plt.show()
+```
+
+We’ll use the gradient of the loss to do stochastic gradient descent.
 
 (Technically, we will be doing gradient descent, rather than stochastic
-gradient descent, since will not randomize over sample points when we
+gradient descent, since we will not randomize over sample points when we
 evaluate the gradient.)
 
 ```{code-cell} ipython3
@@ -382,11 +385,11 @@ loss_gradient = jax.jit(jax.grad(loss_fn))
 The gradient of `loss_fn` is with respect to the first argument `θ`.
 
 The code above seems kind of magical, since we are differentiating with respect
-to a parameter “vector” stored as a list of dictionaries containing arrays.
+to a parameter “vector” stored as a list of named tuples containing arrays.
 
 How can we differentiate with respect to such a complex object?
 
-The answer is that the list of dictionaries is treated internally as a
+The answer is that the list of named tuples is treated internally as a
 [pytree](https://docs.jax.dev/en/latest/pytrees.html).
 
 The JAX function `grad` understands how to
@@ -407,8 +410,8 @@ In this case, to keep things as simple as possible, we’ll use a fixed learning
 ```{code-cell} ipython3
 def update_parameters(
         θ: list,            # Current parameters (pytree)
-        x: jnp.ndarray,     # Input data
-        y: jnp.ndarray,     # Target data
+        x: jax.Array,     # Input data
+        y: jax.Array,     # Target data
         config: Config      # contains configuration data
     ):
     """
@@ -442,8 +445,8 @@ Here’s code that puts this all together.
 @partial(jax.jit, static_argnames=['config'])
 def train_jax_model(
         θ: list,                    # Initial parameters (pytree)
-        x: jnp.ndarray,             # Training input data
-        y: jnp.ndarray,             # Training target data
+        x: jax.Array,             # Training input data
+        y: jax.Array,             # Training target data
         config: Config              # contains configuration data
     ):
     """
@@ -491,13 +494,7 @@ Despite the simplicity of our implementation, we actually perform slightly bette
 Here's a visualization of the quality of our fit.
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots()
-ax.scatter(x_validate, y_validate, color='red', alpha=0.5)
-ax.plot(x_validate.flatten(), f(θ, x_validate).flatten(),
-        label="fitted model", color='black')
-ax.set_xlabel('x')
-ax.set_ylabel('y')
-plt.show()
+plot_jax_output(θ, x_validate, y_validate)
 ```
 
 ## JAX plus Optax
@@ -515,8 +512,8 @@ Here’s a training routine using Optax’s stochastic gradient descent solver.
 @partial(jax.jit, static_argnames=['config'])
 def train_jax_optax(
         θ: list,                    # Initial parameters (pytree)
-        x: jnp.ndarray,             # Training input data
-        y: jnp.ndarray,             # Training target data
+        x: jax.Array,             # Training input data
+        y: jax.Array,             # Training target data
         config: Config              # contains configuration data
     ):
     " Train model using Optax SGD optimizer. "
@@ -562,19 +559,13 @@ print(f"Final MSE on validation data = {optax_sgd_mse:.6f}")
 ```
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots()
-ax.scatter(x_validate, y_validate, color='red', alpha=0.5)
-ax.plot(x_validate.flatten(), f(θ, x_validate).flatten(),
-        label="fitted model", color='black')
-ax.set_xlabel('x')
-ax.set_ylabel('y')
-plt.show()
+plot_jax_output(θ, x_validate, y_validate)
 ```
 
-### Optax with ADAM
+### Optax with Adam
 
 We can also consider using a slightly more sophisticated gradient-based method,
-such as [ADAM](https://arxiv.org/pdf/1412.6980).
+such as [Adam](https://arxiv.org/pdf/1412.6980).
 
 You will notice that the syntax for using this alternative optimizer is very
 similar.
@@ -583,11 +574,11 @@ similar.
 @partial(jax.jit, static_argnames=['config'])
 def train_jax_optax_adam(
         θ: list,                    # Initial parameters (pytree)
-        x: jnp.ndarray,             # Training input data
-        y: jnp.ndarray,             # Training target data
+        x: jax.Array,             # Training input data
+        y: jax.Array,             # Training target data
         config: Config              # contains configuration data
     ):
-    " Train model using Optax ADAM optimizer. "
+    " Train model using Optax Adam optimizer. "
     epochs = config.epochs
     learning_rate = config.learning_rate
     solver = optax.adam(learning_rate)
@@ -622,20 +613,14 @@ optax_adam_runtime = time() - start_time
 
 optax_adam_mse = loss_fn(θ, x_validate, y_validate)
 optax_adam_train_mse = loss_fn(θ, x_train, y_train)
-print(f"Trained model with JAX and Optax ADAM in {optax_adam_runtime:.2f} seconds.")
+print(f"Trained model with JAX and Optax Adam in {optax_adam_runtime:.2f} seconds.")
 print(f"Final MSE on validation data = {optax_adam_mse:.6f}")
 ```
 
 Here's a visualization of the result.
 
 ```{code-cell} ipython3
-fig, ax = plt.subplots()
-ax.scatter(x_validate, y_validate, color='red', alpha=0.5)
-ax.plot(x_validate.flatten(), f(θ, x_validate).flatten(),
-        label="fitted model", color='black')
-ax.set_xlabel('x')
-ax.set_ylabel('y')
-plt.show()
+plot_jax_output(θ, x_validate, y_validate)
 ```
 
 ## Summary
@@ -647,14 +632,8 @@ Here we compare the performance of the four different training approaches we exp
 
 import pandas as pd
 
-# Compute training MSEs for each method
-# Need to retrieve the trained models and compute training MSE
-# For Keras, we already have the model
+# Compute Keras training MSE (JAX training MSEs were computed above)
 keras_train_mse = model.evaluate(x_train, y_train, verbose=0)
-
-# For JAX methods, we need to compute using loss_fn with the final θ from each method
-# We need to re-train or save the θ from each method
-# For now, let's add these calculations after each training section
 
 # Create summary table
 results = {
@@ -662,7 +641,7 @@ results = {
         'Keras',
         'Pure JAX (hand-coded GD)',
         'JAX + Optax SGD',
-        'JAX + Optax ADAM'
+        'JAX + Optax Adam'
     ],
     'Runtime (s)': [
         keras_runtime,
@@ -697,7 +676,7 @@ All methods achieve similar validation MSE values (around 0.043-0.045).
 
 At the time of writing, the MSEs from plain vanilla Optax and our own hand-coded SGD routine are identical.
 
-The ADAM optimizer achieves slightly better MSE by using adaptive learning rates.
+The Adam optimizer achieves slightly better MSE by using adaptive learning rates.
 
 Still, our hand-coded algorithm does very well compared to this high-quality optimizer.
 
@@ -779,7 +758,7 @@ print(f"Strategy 1 - Deeper network (6 layers, k=6)")
 print(f"  Total parameters: 187")
 print(f"  Runtime: {deep_runtime:.2f}s")
 print(f"  Validation MSE: {deep_mse:.6f}")
-print(f"  Improvement over ADAM: {optax_adam_mse - deep_mse:.6f}")
+print(f"  Improvement over Adam: {optax_adam_mse - deep_mse:.6f}")
 ```
 
 **Strategy 2: Deeper Network + Learning Rate Schedule**
@@ -792,8 +771,8 @@ Since the deeper network performed best, let's combine it with the learning rate
 
 def train_deep_with_schedule(
         θ: list,
-        x: jnp.ndarray,
-        y: jnp.ndarray,
+        x: jax.Array,
+        y: jax.Array,
         config: Config
     ):
     " Train deeper network with learning rate schedule. "
@@ -832,7 +811,7 @@ deep_schedule_mse = loss_fn(θ_deep_schedule, x_validate, y_validate)
 print(f"Strategy 2 - Deeper network + LR schedule")
 print(f"  Runtime: {deep_schedule_runtime:.2f}s")
 print(f"  Validation MSE: {deep_schedule_mse:.6f}")
-print(f"  Improvement over ADAM: {optax_adam_mse - deep_schedule_mse:.6f}")
+print(f"  Improvement over Adam: {optax_adam_mse - deep_schedule_mse:.6f}")
 ```
 
 **Strategy 3: Deeper Network + LR Schedule + L2 Regularization**
@@ -845,8 +824,8 @@ Let's add L2 regularization (similar to ridge regression) to penalize complexity
 
 def train_deep_with_schedule_and_l2(
         θ: list,
-        x: jnp.ndarray,
-        y: jnp.ndarray,
+        x: jax.Array,
+        y: jax.Array,
         config: Config,
         lambda_l2: float = 0.001
     ):
@@ -899,7 +878,7 @@ deep_l2_mse = loss_fn(θ_deep_l2, x_validate, y_validate)
 print(f"Strategy 3 - Deeper network + LR schedule + L2 regularization")
 print(f"  Runtime: {deep_l2_runtime:.2f}s")
 print(f"  Validation MSE: {deep_l2_mse:.6f}")
-print(f"  Improvement over ADAM: {optax_adam_mse - deep_l2_mse:.6f}")
+print(f"  Improvement over Adam: {optax_adam_mse - deep_l2_mse:.6f}")
 ```
 
 **Strategy 4: Baseline + L2 Regularization**
@@ -912,8 +891,8 @@ Let's see if L2 regularization helps the baseline architecture:
 
 def train_baseline_with_l2(
         θ: list,
-        x: jnp.ndarray,
-        y: jnp.ndarray,
+        x: jax.Array,
+        y: jax.Array,
         config: Config,
         lambda_l2: float = 0.001
     ):
@@ -962,7 +941,7 @@ baseline_l2_mse = loss_fn(θ_baseline_l2, x_validate, y_validate)
 print(f"Strategy 4 - Baseline + L2 regularization")
 print(f"  Runtime: {baseline_l2_runtime:.2f}s")
 print(f"  Validation MSE: {baseline_l2_mse:.6f}")
-print(f"  Improvement over ADAM: {optax_adam_mse - baseline_l2_mse:.6f}")
+print(f"  Improvement over Adam: {optax_adam_mse - baseline_l2_mse:.6f}")
 ```
 
 **Results Summary**
@@ -975,7 +954,7 @@ Let's compare all strategies:
 # Summary of all strategies
 strategies_results = {
     'Strategy': [
-        'Baseline (ADAM + tanh)',
+        'Baseline (Adam + tanh)',
         '1. Deeper network (6 layers)',
         '2. Deeper network + LR schedule',
         '3. Strategy 2 + L2 regularization',

--- a/lectures/jax_nn.md
+++ b/lectures/jax_nn.md
@@ -86,7 +86,7 @@ the overall mapping is
 
 $$ \mathbb R \to \mathbb R^k \to \mathbb R^k \to \mathbb R^k \to \mathbb R $$
 
-Here's a class to store the learning-related constants we’ll use across all implementations.
+Here's a class to store the learning-related constants we'll use across all implementations.
 
 Our default value of $k$ will be 10.
 
@@ -231,7 +231,7 @@ The fit is good and we note the relatively low final MSE.
 For the JAX implementation, we need to construct the network ourselves, as a map
 from inputs to outputs.
 
-We’ll use the same network structure we used for the Keras implementation.
+We'll use the same network structure we used for the Keras implementation.
 
 ### Background and set up
 
@@ -319,14 +319,14 @@ def initialize_network(
 
 Wait, you say!
 
-Shouldn’t we concatenate the elements of $ \theta $ into some kind of big array, so that we can do autodiff with respect to this array?
+Shouldn't we concatenate the elements of $ \theta $ into some kind of big array, so that we can do autodiff with respect to this array?
 
-Actually we don’t need to --- we use the JAX PyTree approach discussed below.
+Actually we don't need to --- we use the JAX PyTree approach discussed below.
 
 
 ### Coding the network
 
-Here’s our implementation of the ANN $f$:
+Here's our implementation of the ANN $f$:
 
 ```{code-cell} ipython3
 def f(
@@ -359,20 +359,20 @@ def loss_fn(
     return jnp.mean((f(θ, x) - y)**2)
 ```
 
-We’ll also define a function to visualize predictions from our JAX models.
+We'll also define a function to visualize predictions from our JAX models.
 
 ```{code-cell} ipython3
 def plot_jax_output(θ, x_validate, y_validate):
     fig, ax = plt.subplots()
-    ax.scatter(x_validate, y_validate, color=’red’, alpha=0.5)
+    ax.scatter(x_validate, y_validate, color='red', alpha=0.5)
     ax.plot(x_validate.flatten(), f(θ, x_validate).flatten(),
-            label="fitted model", color=’black’)
-    ax.set_xlabel(‘x’)
-    ax.set_ylabel(‘y’)
+            label="fitted model", color='black')
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
     plt.show()
 ```
 
-We’ll use the gradient of the loss to do stochastic gradient descent.
+We'll use the gradient of the loss to do stochastic gradient descent.
 
 (Technically, we will be doing gradient descent, rather than stochastic
 gradient descent, since we will not randomize over sample points when we
@@ -385,7 +385,7 @@ loss_gradient = jax.jit(jax.grad(loss_fn))
 The gradient of `loss_fn` is with respect to the first argument `θ`.
 
 The code above seems kind of magical, since we are differentiating with respect
-to a parameter “vector” stored as a list of named tuples containing arrays.
+to a parameter "vector" stored as a list of named tuples containing arrays.
 
 How can we differentiate with respect to such a complex object?
 
@@ -405,7 +405,7 @@ The JAX function `grad` understands how to
 Using the above code, we can now write our rule for updating the parameters via gradient descent, which is the
 algorithm we covered in our [lecture on autodiff](https://jax.quantecon.org/autodiff.html).
 
-In this case, to keep things as simple as possible, we’ll use a fixed learning rate for every iteration.
+In this case, to keep things as simple as possible, we'll use a fixed learning rate for every iteration.
 
 ```{code-cell} ipython3
 def update_parameters(
@@ -439,7 +439,7 @@ of trees.
 Each weight matrix and bias vector is updated by gradient
 descent, exactly as required.
 
-Here’s code that puts this all together.
+Here's code that puts this all together.
 
 ```{code-cell} ipython3
 @partial(jax.jit, static_argnames=['config'])
@@ -506,7 +506,7 @@ One such library is [Optax](https://optax.readthedocs.io/en/latest/).
 
 ### Optax with SGD
 
-Here’s a training routine using Optax’s stochastic gradient descent solver.
+Here's a training routine using Optax's stochastic gradient descent solver.
 
 ```{code-cell} ipython3
 @partial(jax.jit, static_argnames=['config'])
@@ -536,7 +536,7 @@ def train_jax_optax(
     return θ_final
 ```
 
-Let’s try running it.
+Let's try running it.
 
 ```{code-cell} ipython3
 # Reset parameter vector

--- a/lectures/keras.md
+++ b/lectures/keras.md
@@ -16,23 +16,21 @@ kernelspec:
 ```{include} _admonition/gpu.md
 ```
 
-In this lecture we show how to implement one-dimensional nonlinear regression
-using a neural network.
+In this lecture we show how to implement one-dimensional nonlinear regression using a neural network.
 
-We will use the popular deep learning library [Keras](https://keras.io/), which
-provides a simple interface to deep learning.
+We will use [Keras](https://keras.io/), a popular and relatively simple library for deep learning.
 
 The emphasis in Keras is on providing an intuitive API, while the heavy lifting is
 done by one of several possible backends.
 
-Currently the backend library options are Tensorflow, PyTorch, and JAX.
+Currently the backend library options are TensorFlow, PyTorch, and JAX.
 
 In this lecture we will use JAX.
 
-The objective of this lecture is to provide a very simple introduction to deep
-learning in a regression setting.
+Our main task is to provide an elementary introduction to deep learning in a regression setting.
 
-Later, in {doc}`a separate lecture <jax_nn>`, we will investigate how to do the same learning task using pure JAX, rather than relying on Keras.
+Later, in {doc}`a separate lecture <jax_nn>`, we will investigate how to do the
+same learning task using JAX directly, rather than relying on Keras.
 
 We begin this lecture with some standard imports.
 
@@ -58,7 +56,15 @@ os.environ['KERAS_BACKEND'] = 'jax'
 
 Now we should be able to import some tools from Keras.
 
-(Without setting the backend to JAX, these imports might fail -- unless you have PyTorch or Tensorflow set up.)
+```{note}
+Without setting the backend to JAX, the imports below might fail (unless you have PyTorch or TensorFlow set up).
+
+If you have problems running the next cell in Jupyter, try 
+
+1. quitting
+2. running `export KERAS_BACKEND="jax"` 
+3. starting Jupyter on the command line from the same terminal.
+```
 
 ```{code-cell} ipython3
 import keras
@@ -91,10 +97,10 @@ def generate_data(x_min=0,           # Minimum x value
                   x_max=5,           # Max x value
                   data_size=400,     # Default size for dataset
                   seed=1234):
-    np.random.seed(seed)
+    rng = np.random.default_rng(seed)
     x = np.linspace(x_min, x_max, num=data_size)
     
-    ϵ = 0.2 * np.random.randn(data_size)
+    ϵ = 0.2 * rng.standard_normal(data_size)
     y = x**0.5 + np.sin(x) + ϵ
     # Keras expects two dimensions, not flat arrays
     x, y = [np.reshape(z, (data_size, 1)) for z in (x, y)]
@@ -117,17 +123,17 @@ ax.set_ylabel('y')
 plt.show()
 ```
 
-We'll also use data from the same process for cross-validation.
+We'll also use data from the same process for validation.
 
 ```{code-cell} ipython3
-x_validate, y_validate = generate_data()
+x_validate, y_validate = generate_data(seed=5678)
 ```
 
 ## Models
 
 We supply functions to build two types of models.
 
-## Regression model
+### Regression model
 
 The first implements linear regression.
 
@@ -135,7 +141,7 @@ This is achieved by constructing a neural network with just one layer, that maps
 to a single dimension (since the prediction is real-valued).
 
 The object `model` will be an instance of `keras.Sequential`, which is used to
-group a stack of layers into a single prediction model.
+stack layers into a single prediction model.
 
 ```{code-cell} ipython3
 def build_regression_model():
@@ -154,23 +160,22 @@ In the function above you can see that
 * we use stochastic gradient descent to train the model, and
 * the loss is mean squared error (MSE).
 
-The call `model.add` adds a single layer the activation function equal to the identity map.
+The call `model.add` adds a single layer with the activation function equal to the identity map.
 
 MSE is the standard loss function for ordinary least squares regression.
 
 ### Deep Network
 
 The second function creates a dense (i.e., fully connected) neural network with
-3 hidden layers, where each hidden layer maps to a k-dimensional output space.
+3 hidden layers, where each hidden layer maps to a 10-dimensional output space.
 
 ```{code-cell} ipython3
 def build_nn_model(output_dim=10, num_layers=3, activation_function='tanh'):
-    # Create a Keras Model instance using Sequential()
     model = Sequential()
     # Add layers to the network sequentially, from inputs towards outputs
     for i in range(num_layers):
         model.add(Dense(units=output_dim, activation=activation_function))
-    # Add a final layer that maps to a scalar value, for regression.
+    # Add a final layer that maps to a scalar value, the prediction.
     model.add(Dense(units=1))
     # Embed training configurations
     model.compile(optimizer=keras.optimizers.SGD(), 
@@ -183,8 +188,7 @@ def build_nn_model(output_dim=10, num_layers=3, activation_function='tanh'):
 The following function will be used to plot the MSE of the model during the
 training process.
 
-Initially the MSE will be relatively high, but it should fall at each iteration,
-as the parameters are adjusted to better fit the data.
+The MSE should fall as the parameters are adjusted to better fit the data.
 
 ```{code-cell} ipython3
 def plot_loss_history(training_history, ax):
@@ -205,7 +209,7 @@ def plot_loss_history(training_history, ax):
 
 ## Training
 
-Now let's go ahead and train our  models.
+Now let's go ahead and train our models.
 
 
 ### Linear regression
@@ -232,14 +236,14 @@ plot_loss_history(training_history, ax)
 plt.show()
 ```
 
-Let's print the final MSE on the cross-validation data.
+Let's print the final MSE on the validation data.
 
 ```{code-cell} ipython3
 print("Testing loss on the validation set.")
 regression_model.evaluate(x_validate, y_validate, verbose=2)
 ```
 
-Here's our output predictions on the cross-validation data.
+Here's our output predictions on the validation data.
 
 ```{code-cell} ipython3
 y_predict = regression_model.predict(x_validate, verbose=2)
@@ -255,7 +259,7 @@ def plot_results(x, y, y_predict, ax):
     ax.set_ylabel('y')
 ```
 
-Let's now call the function on the cross-validation data.
+Let's now call the function on the validation data.
 
 ```{code-cell} ipython3
 fig, ax = plt.subplots()
@@ -302,14 +306,6 @@ y_predict = nn_model.predict(x_validate, verbose=2)
 ```
 
 ```{code-cell} ipython3
-def plot_results(x, y, y_predict, ax):
-    ax.scatter(x, y)
-    ax.plot(x, y_predict, label="fitted model", color='black')
-    ax.set_xlabel('x')
-    ax.set_ylabel('y')
-```
-
-```{code-cell} ipython3
 fig, ax = plt.subplots()
 plot_results(x_validate, y_validate, y_predict, ax)
 plt.show()
@@ -317,4 +313,4 @@ plt.show()
 
 Not surprisingly, the multilayer neural network does a much better job of fitting the data.
 
-In a {doc}`a follow-up lecture <jax_nn>`, we will try to achieve the same fit using pure JAX, rather than relying on the Keras front-end.
+In {doc}`a follow-up lecture <jax_nn>`, we will try to achieve the same fit using pure JAX, rather than relying on the Keras front-end.


### PR DESCRIPTION
## Summary

- Fix miscellaneous errors and modernize the `keras` and `jax_nn` neural network lectures

## Changes

### `keras.md`

- **Fix validation bug**: validation data was using the same seed as training data (`seed=1234`), so "validation" was evaluating on identical data. Changed to `seed=5678`
- **Fix incorrect terminology**: replaced "cross-validation" with "validation" throughout (the lecture does a train/validation split, not k-fold cross-validation)
- **Modernize NumPy RNG**: replaced legacy `np.random.seed` / `np.random.randn` with modern `np.random.default_rng` / `rng.standard_normal` API
- **Fix heading level**: "Regression model" was `##` (h2) but should be `###` (h3) under the "Models" h2, matching its sibling "Deep Network"
- **Remove duplicate code**: removed second identical definition of `plot_results`
- **Fix typos**: "adds a single layer the activation" → "with the", "train our  models" → "train our models", "In a a follow-up" → "In a follow-up"
- **Fix spelling**: "Tensorflow" → "TensorFlow"
- **Move Keras backend note**: moved the detailed troubleshooting note about `KERAS_BACKEND` from `jax_nn.md` to here, where the backend is first introduced

### `jax_nn.md`

- **Fix incorrect description**: parameters are stored as "named tuples" not "dictionaries" (two occurrences)
- **Fix typos**: "of a the network" → "of the network", "corresponding  to" → "corresponding to", "since will not" → "since we will not"
- **Fix capitalization**: "ADAM" → "Adam" throughout (it's not an acronym — the original paper styles it "Adam")
- **Modernize type hints**: replaced deprecated `jnp.ndarray` with `jax.Array` throughout
- **Remove unnecessary f-string**: `f"Training NN using Keras."` → `"Training NN using Keras."`
- **Extract reusable plotting function**: added `plot_jax_output` to replace three identical scatter+line plot blocks; placed after `f` and `loss_fn` definitions so it follows its dependencies
- **Simplify `plot_keras_output`**: removed unused `x, y` parameters
- **Clean up TODO comments**: removed leftover development notes in summary table code
- **Move Keras backend note**: moved to `keras.md` where it belongs

## Test plan

- [x] Converted `keras.md` to Python via jupytext and ran successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)