### PR TITLE
[kesten_processes] update JAX

### DIFF
--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -275,10 +275,10 @@ by
 * replacing the `for` loop with [`lax.fori_loop`](https://jax.readthedocs.io/en/latest/_autosummary/jax.lax.fori_loop.html) and
 * JIT-compiling the whole function.
 
-Here a the `lax.fori_loop` version:
+Here is the `lax.fori_loop` version:
 
 ```{code-cell} ipython3
-@jax.jit
+@partial(jax.jit, static_argnames=("T", "M"))
 def generate_cross_section_lax(
         firm, T=500, M=500_000, s_init=1.0, seed=123
     ):
@@ -298,7 +298,7 @@ def generate_cross_section_lax(
         e = μ_e + σ_e * random.normal(subkeys[2], (M,))
         # Exponentiate them
         a, b, e = jax.tree.map(jnp.exp, (a, b, e))
-        # Pull out the t-th cross-section of shocks
+        # Update the cross-section of firms
         s = jnp.where(s < s_bar, e, a * s + b)
         new_state = s, key
         return new_state
@@ -361,7 +361,7 @@ What are the pros and cons of this approach?
 ```
 
 ```{code-cell} ipython3
-@jax.jit
+@partial(jax.jit, static_argnames=("T", "M"))
 def generate_cross_section_lax(
         firm, T=500, M=500_000, s_init=1.0, seed=123
     ):
@@ -385,7 +385,7 @@ def generate_cross_section_lax(
         s = jnp.where(s < s_bar, e_t, a_t * s + b_t)
         return s
 
-    # Use lax.scan to perform the calculations on all states
+    # Use lax.fori_loop to perform the calculations on all states
     s_final = lax.fori_loop(0, T, update_cross_section, s)
     return s_final
 ```


### PR DESCRIPTION
Hi @jstac,

This PR updates the JAX `lax.fori_loop` examples in the Kesten Processes lecture following #315 

Changes:
- mark `T` and `M` as static in the jitted `generate_cross_section_lax` examples
- fix a typo in the `lax.fori_loop` section
- clarify a comment in the first `lax.fori_loop` example where shocks are generated inside the loop
- update the exercise-solution comment to refer to `lax.fori_loop` rather than `lax.scan`

Best,
Longye