### PR TITLE
[wealth_dynamics] Update code and exercises

### DIFF
--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -363,7 +363,7 @@ z_sequence = jnp.array(z_sequence)
 
 ```{code-cell} ipython3
 print("Generating cross-section using JAX")
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 start = time()
 ψ_star = update_cross_section_jax(model, ψ_0, z_sequence, key).block_until_ready()
 jax_with_compile = time() - start
@@ -372,7 +372,7 @@ print(f"Generated cross-section in {jax_with_compile} seconds.\n")
 
 ```{code-cell} ipython3
 print("Repeating without compile time.")
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 start = time()
 ψ_star = update_cross_section_jax(model, ψ_0, z_sequence, key).block_until_ready()
 jax_without_compile = time() - start
@@ -432,7 +432,7 @@ update_cross_section_jax_compiled = jax.jit(
 
 ```{code-cell} ipython3
 print("Generating cross-section using JAX with compiled loop")
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 start = time()
 ψ_star = update_cross_section_jax_compiled(
         model, ψ_0, num_households, z_sequence, key
@@ -443,7 +443,7 @@ print(f"Generated cross-section in {jax_fori_with_compile} seconds.\n")
 
 ```{code-cell} ipython3
 print("Repeating without compile time")
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 start = time()
 ψ_star = update_cross_section_jax_compiled(
         model, ψ_0, num_households, z_sequence, key
@@ -470,7 +470,7 @@ In the limit, data that obeys a power law generates a straight line.
 
 ```{code-cell} ipython3
 model = create_wealth_model()
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 ψ_star = update_cross_section_jax_compiled(
         model, ψ_0, num_households, z_sequence, key
 )
@@ -532,7 +532,7 @@ z_sequence = jnp.array(z_sequence)
 ```
 
 ```{code-cell} ipython3
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 ψ_star = update_cross_section_jax_compiled(
         model, ψ_0, num_households, z_sequence, key
 )
@@ -689,7 +689,7 @@ across parameter values so that differences in the curves mainly reflect
 parameter changes rather than different random draws.
 
 ```{code-cell} ipython3
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 fig, ax = plt.subplots()
 gini_vals = []
 for μ_r in μ_r_vals:
@@ -749,7 +749,7 @@ To isolate the role of volatility, set $\mu_r = - \sigma_r^2 / 2$ at each $\sigm
 Here's one solution
 
 ```{code-cell} ipython3
-key = jax.random.PRNGKey(1234)
+key = jax.random.key(1234)
 fig, ax = plt.subplots()
 
 gini_vals = []

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -214,7 +214,7 @@ def wealth_time_series(model, w_0, sim_length):
     a, b, σ_z, z_mean, z_var = aggregate_params 
     # Initialize and update
     z = generate_aggregate_state_sequence(aggregate_params, 
-                                          length=sim_length)
+                                          length=sim_length-1)
     w = np.empty(sim_length)
     w[0] = w_0
     for t in range(sim_length-1):
@@ -257,10 +257,12 @@ def update_cross_section(model, w_distribution, z_sequence):
     Takes 
 
         * a current distribution of wealth values as w_distribution and
-        * an aggregate shock sequence z_sequence
+        * an aggregate state sequence z_sequence
 
-    and updates each w_t in w_distribution to w_{t+j}, where
-    j = len(z_sequence).
+    The first entry of z_sequence is the initial aggregate state.
+
+    It then updates each w_t in w_distribution to w_{t+j}, where
+    j = len(z_sequence) - 1.
 
     Returns the new distribution.
 
@@ -275,7 +277,7 @@ def update_cross_section(model, w_distribution, z_sequence):
     # Update each household
     for i in numba.prange(num_households):
         w = w_distribution[i]
-        for t in range(sim_length):
+        for t in range(1, len(z)):
             w = update_wealth(household_params, w, z[t])
         new_distribution[i] = w
     return new_distribution
@@ -323,10 +325,12 @@ def update_cross_section_jax(model, w_distribution, z_sequence, key):
     Takes 
 
         * a current distribution of wealth values as w_distribution and
-        * an aggregate shock sequence z_sequence
+        * an aggregate state sequence z_sequence
 
-    and updates each w_t in w_distribution to w_{t+j}, where
-    j = len(z_sequence).
+    The first entry of z_sequence is the initial aggregate state.
+
+    It then updates each w_t in w_distribution to w_{t+j}, where
+    j = len(z_sequence) - 1.
 
     Returns the new distribution.
 
@@ -338,7 +342,7 @@ def update_cross_section_jax(model, w_distribution, z_sequence, key):
     n = len(w)
 
     # Update wealth
-    for t, z in enumerate(z_sequence):
+    for z in z_sequence[1:]:
         U = jax.random.normal(key, (2, n))
         y = c_y * jnp.exp(z) + jnp.exp(μ_y + σ_y * U[0, :])
         R = c_r * jnp.exp(z) + jnp.exp(μ_r + σ_r * U[1, :])
@@ -392,10 +396,12 @@ def update_cross_section_jax_compiled(model,
     Takes 
 
         * a current distribution of wealth values as w_distribution and
-        * an aggregate shock sequence z_sequence
+        * an aggregate state sequence z_sequence
 
-    and updates each w_t in w_distribution to w_{t+j}, where
-    j = len(z_sequence).
+    The first entry of z_sequence is the initial aggregate state.
+
+    It then updates each w_t in w_distribution to w_{t+j}, where
+    j = len(z_sequence) - 1.
 
     Returns the new distribution.
 
@@ -405,7 +411,7 @@ def update_cross_section_jax_compiled(model,
     w_hat, s_0, c_y, μ_y, σ_y, c_r, μ_r, σ_r, y_mean = household_params
     w = w_distribution
     n = len(w)
-    z = z_sequence
+    z = z_sequence[1:]
     sim_length = len(z)
 
     def body_function(t, state):

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -116,7 +116,7 @@ where $s_0$ is a positive constant.
 Thus, 
 
 * for $w < \hat w$, the household saves nothing, while
-* for $w \geq \bar w$, the household saves a fraction $s_0$ of their wealth.
+* for $w \geq \hat w$, the household saves a fraction $s_0$ of their wealth.
 
 ## Implementation 
 

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -343,11 +343,11 @@ def update_cross_section_jax(model, w_distribution, z_sequence, key):
 
     # Update wealth
     for z in z_sequence[1:]:
-        U = jax.random.normal(key, (2, n))
+        key, subkey = jax.random.split(key)
+        U = jax.random.normal(subkey, (2, n))
         y = c_y * jnp.exp(z) + jnp.exp(μ_y + σ_y * U[0, :])
         R = c_r * jnp.exp(z) + jnp.exp(μ_r + σ_r * U[1, :])
         w = y + jnp.where(w < w_hat, 0.0, R * s_0 * w) 
-        key, subkey = jax.random.split(key)
 
     return w
 ```
@@ -687,6 +687,10 @@ Do the outcomes match your intuition?
 
 Here is one solution
 
+In this and the following parameter comparisons, we reuse the same random seed
+across parameter values so that differences in the curves mainly reflect
+parameter changes rather than different random draws.
+
 ```{code-cell} ipython3
 key = jax.random.PRNGKey(1234)
 fig, ax = plt.subplots()
@@ -700,7 +704,7 @@ for μ_r in μ_r_vals:
     g = gini_jax(ψ_star, num_households)
     ax.plot(x, y, label=f'$\psi^*$ at $\mu_r = {μ_r:0.2}$')
     gini_vals.append(g)
-ax.plot(x, y, label='equality')
+ax.plot(x, x, label='equality')
 ax.legend(loc="upper left")
 plt.show()
 ```
@@ -736,7 +740,7 @@ Use the same initial condition as before and the sequence
 
 To isolate the role of volatility, set $\mu_r = - \sigma_r^2 / 2$ at each $\sigma_r$.
 
-(This holds the variance of the idiosyncratic term $\exp(\mu_r + \sigma_r \zeta)$ constant.)
+(This holds the mean of the idiosyncratic term $\exp(\mu_r + \sigma_r \xi)$ constant.)
 
 ```{exercise-end}
 ```
@@ -761,7 +765,7 @@ for σ_r in σ_r_vals:
     g = gini_jax(ψ_star, num_households)
     ax.plot(x, y, label=f'$\psi^*$ at $\sigma_r = {σ_r:0.2}$')
     gini_vals.append(g)
-ax.plot(x, y, label='equality')
+ax.plot(x, x, label='equality')
 ax.legend(loc="upper left")
 plt.show()
 ```

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -71,9 +71,6 @@ Wealth evolves as follows:
     w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 
-In the simulations below, $z_{t+1}$ and the period $t+1$ idiosyncratic shocks
-are drawn before updating wealth from $w_t$ to $w_{t+1}$.
-
 Here
 
 - $w_t$ is wealth at time $t$ for a given household,

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -71,6 +71,9 @@ Wealth evolves as follows:
     w_{t+1} = (1 + r_{t+1}) s(w_t) + y_{t+1}
 ```
 
+In the simulations below, $z_{t+1}$ and the period $t+1$ idiosyncratic shocks
+are drawn before updating wealth from $w_t$ to $w_{t+1}$.
+
 Here
 
 - $w_t$ is wealth at time $t$ for a given household,

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -32,6 +32,9 @@ One of our interests will be how different aspects of wealth dynamics -- such
 as labor income and the rate of return on investments -- feed into measures of
 inequality, such as the Gini coefficient.
 
+Because the analysis below requires simulating large cross sections of households,
+it provides a natural setting for JAX's array-based programming model and accelerator support.
+
 In addition to JAX and Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython3


### PR DESCRIPTION
Hi @jstac 

This PR update the lecture `wealth_dynamics` according to #321 .

In particular, this PR:

- Added a brief opening sentence explaining that large cross-section simulations make the lecture a natural fit for JAX.

- Fixed the savings-threshold notation so the text uses `\hat w`, matching the displayed savings rule.

- Added a timing note clarifying that period `t+1` shocks are drawn before updating wealth from `w_t` to `w_{t+1}`.

- Made Numba and JAX cross-section updates consistently skip `z_sequence[0]` and use `z_sequence[1:]`.

- Updated the first JAX loop to split the PRNG key before drawing random shocks.

- Fixed Exercises 2 and 3 so the equality benchmark is plotted as the 45-degree line.

- Corrected Exercise 3 to say `\mu_r = -\sigma_r^2 / 2` holds the lognormal mean constant, not the variance.

- Added a note explaining that reused PRNG seeds support common-random-number comparisons across parameter values.