### PR TITLE
⚙️ Disable spot instances on GPU runners (use on-demand)

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   cache:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Build Preview [using jupyter-book]
 on: [pull_request]
 jobs:
   preview:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -2,7 +2,7 @@ name: Build Project on Google Collab (Execution)
 on: [pull_request]
 jobs:
   execution-checks:
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=ubuntu24-gpu-x64/volume=80gb/spot=false"
     container:
       image: docker://us-docker.pkg.dev/colab-images/public/runtime
       options: --gpus all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb"
+    runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Forces **on-demand** GPU capacity instead of spot by adding `spot=false` to the RunsOn runner spec in all four GPU workflows: `cache.yml`, `ci.yml`, `publish.yml`, and `collab.yml`.

## Why

AWS spot reclamation is increasingly interrupting our long GPU notebook builds mid-run. In the most recent weekly cache build ([run 27929889850](https://github.com/QuantEcon/lecture-jax/actions/runs/27929889850)) the `g4dn.2xlarge` spot instance received a shutdown signal at **91%** of the build (`reading sources... [91%]`), producing `The runner has received a shutdown signal` followed by `The operation was canceled`. The downstream `AssertionError: self.km is not None` in `nbclient` cleanup is a symptom of the kernel being killed mid-execution, not a real notebook failure.

These builds run 17–22 minutes on a single GPU, so a reclamation near the end wastes the entire run (and any spot savings along with it). On-demand trades a higher hourly rate for build reliability, which is the right call for GPU jobs that can't cheaply checkpoint and resume.

## Change

| Workflow | Trigger | Runner spec |
|---|---|---|
| `cache.yml` | weekly schedule | `…/volume=80gb/spot=false` |
| `ci.yml` | pull_request | `…/volume=80gb/spot=false` |
| `publish.yml` | `publish*` tag | `…/volume=80gb/spot=false` |
| `collab.yml` | pull_request | `…/volume=80gb/spot=false` |

## Notes

- Tracking the broader pattern across GPU-using lecture repos in a QuantEcon/meta issue.
- If we'd rather keep spot for the cheaper/shorter PR jobs (`ci.yml`, `collab.yml`) and only force on-demand for the long `cache.yml`/`publish.yml` builds, that's an easy narrowing — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
