### PR TITLE
[collab] Source pip dependencies from environment.yml

### DIFF
--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -28,11 +28,14 @@ jobs:
           branch: main
           name: build-cache
           path: _build
-      # Install build software
+      # Install build software (pip dependencies sourced from environment.yml
+      # so this stays in sync with the conda build — see #303)
       - name: Install Build Software
         shell: bash -l {0}
         run: |
-          pip install "jupyter-book>=1.0.4post1,<2.0" quantecon-book-theme==0.20.2 sphinx-tojupyter==0.6.0 sphinxext-rediraffe==0.3.0 sphinx-exercise==1.2.1 sphinx-proof==0.4.0 sphinxcontrib-youtube==1.5.0 sphinx-togglebutton==0.4.5 sphinx-reredirects==1.1.0
+          python -c "import yaml; deps = next(d['pip'] for d in yaml.safe_load(open('environment.yml'))['dependencies'] if isinstance(d, dict) and 'pip' in d); open('colab-requirements.txt', 'w').write('\n'.join(deps) + '\n')"
+          cat colab-requirements.txt
+          pip install -r colab-requirements.txt
       # Build of HTML (Execution Testing)
       - name: Build HTML
         shell: bash -l {0}

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Install Build Software
         shell: bash -l {0}
         run: |
+          pip install pyyaml
           python -c "import yaml; deps = next(d['pip'] for d in yaml.safe_load(open('environment.yml'))['dependencies'] if isinstance(d, dict) and 'pip' in d); open('colab-requirements.txt', 'w').write('\n'.join(deps) + '\n')"
           cat colab-requirements.txt
           pip install -r colab-requirements.txt


### PR DESCRIPTION
## What

The Colab execution workflow (`collab.yml`) duplicated the full pip dependency list as a literal `pip install` line. That copy drifted out of sync with `environment.yml`: Dependabot's `conda` ecosystem only updates `environment.yml`, so after #319 bumped `quantecon-book-theme` to 0.21.0 the workflow was still pinned to 0.20.2. This was surfaced (and is now superseded) by #303.

This change derives the pip dependencies from `environment.yml` at build time, giving a single source of truth so the two can no longer diverge:

```yaml
python -c "import yaml; deps = next(d['pip'] for d in yaml.safe_load(open('environment.yml'))['dependencies'] if isinstance(d, dict) and 'pip' in d); open('colab-requirements.txt', 'w').write('\n'.join(deps) + '\n')"
cat colab-requirements.txt
pip install -r colab-requirements.txt
```

## Why this approach

- No Dependabot config change needed — it keeps updating `environment.yml` as before, and the Colab workflow automatically picks up those updates.
- The container is pip-only (Google Colab runtime image), so we extract just the `pip:` subsection rather than recreating the conda env.
- The generated list is printed to the log (`cat colab-requirements.txt`) for visibility.

## Verification

Validated locally that the snippet extracts the correct list (now `quantecon-book-theme==0.21.0`, matching `environment.yml`) and that `collab.yml` is well-formed YAML. The `execution-checks` job on this PR exercises the new install step end-to-end on GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)