### PR TITLE
Replace deprecated tic/toc timers with qe.Timer in kesten_processes

### DIFF
--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -56,7 +56,6 @@ import jax
 import jax.numpy as jnp
 from jax import random
 from jax import lax
-from quantecon import tic, toc
 from typing import NamedTuple
 from functools import partial
 ```
@@ -235,17 +234,15 @@ Let's try running the code and generating a cross-section.
 
 ```{code-cell} ipython3
 firm = Firm()
-tic()
-data = generate_cross_section(firm).block_until_ready()
-toc()
+with qe.Timer():
+    data = generate_cross_section(firm).block_until_ready()
 ```
 
 We run the function again so we can see the speed without compile time.
 
 ```{code-cell} ipython3
-tic()
-data = generate_cross_section(firm).block_until_ready()
-toc()
+with qe.Timer():
+    data = generate_cross_section(firm).block_until_ready()
 ```
 
 Let's produce the rank-size plot and check the distribution:
@@ -299,7 +296,7 @@ def generate_cross_section_lax(
         # Exponentiate them
         a, b, e = jax.tree.map(jnp.exp, (a, b, e))
         # Update the cross-section of firms
-        s = jnp.where(s < s_bar, e, a * s + b)
+        s = jnp.where(s < s_bar, e_t, a_t * s + b_t)
         new_state = s, key
         return new_state
 
@@ -314,15 +311,13 @@ def generate_cross_section_lax(
 Let's see if we get any speed gain
 
 ```{code-cell} ipython3
-tic()
-data = generate_cross_section_lax(firm).block_until_ready()
-toc()
+with qe.Timer():
+    data = generate_cross_section_lax(firm).block_until_ready()
 ```
 
 ```{code-cell} ipython3
-tic()
-data = generate_cross_section_lax(firm).block_until_ready()
-toc()
+with qe.Timer():
+    data = generate_cross_section_lax(firm).block_until_ready()
 ```
 
 Here we produce the same rank-size plot:
@@ -393,15 +388,13 @@ def generate_cross_section_lax(
 Here are the run times.
 
 ```{code-cell} ipython3
-tic()
-data = generate_cross_section_lax(firm).block_until_ready()
-toc()
+with qe.Timer():
+    data = generate_cross_section_lax(firm).block_until_ready()
 ```
 
 ```{code-cell} ipython3
-tic()
-data = generate_cross_section_lax(firm).block_until_ready()
-toc()
+with qe.Timer():
+    data = generate_cross_section_lax(firm).block_until_ready()
 ```
 
 This method might or might not be faster.

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -296,7 +296,7 @@ def generate_cross_section_lax(
         # Exponentiate them
         a, b, e = jax.tree.map(jnp.exp, (a, b, e))
         # Update the cross-section of firms
-        s = jnp.where(s < s_bar, e_t, a_t * s + b_t)
+        s = jnp.where(s < s_bar, e, a * s + b)
         new_state = s, key
         return new_state
 


### PR DESCRIPTION
## Summary

Closes #329.

`quantecon` is deprecating the Matlab-like `tic`/`tac`/`toc` timers in favour of the `Timer` context manager (QuantEcon/QuantEcon.py#833). `lectures/kesten_processes.md` was the only lecture in this repo still using the old API.

## Change

- Dropped the now-unused `from quantecon import tic, toc` import (the lecture already does `import quantecon as qe`).
- Replaced all six `tic()` / `toc()` pairs wrapping a single timed call with the equivalent `with qe.Timer():` context manager, e.g.:

```python
# before
tic()
data = generate_cross_section(firm).block_until_ready()
toc()

# after
with qe.Timer():
    data = generate_cross_section(firm).block_until_ready()
```

This is a purely mechanical, behavior-preserving swap — `qe.Timer()` prints elapsed time on exit by default, matching `toc()`'s existing behavior.

## Testing

This is a documentation/lecture source file (no associated unit tests). Verified by inspecting the `quantecon.util.timing.Timer` context-manager implementation upstream to confirm `with qe.Timer():` is a drop-in replacement for the `tic()`/`toc()` pair used here.