### PR TITLE
INFR: Migrate GitHub Pages deploy to artifact-based workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: write   # write: upload release assets (html archive, checksum, manifest)
+  actions: read     # dawidd6/action-download-artifact reads the cache.yml build artifact
   pages: write
   id-token: write   # required for OIDC-based Pages deployment
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,10 +3,25 @@ on:
   push:
     tags:
       - 'publish*'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write   # write: upload release assets (html archive, checksum, manifest)
+  pages: write
+  id-token: write   # required for OIDC-based Pages deployment
+
+# Allow only one concurrent deployment; don't cancel an in-flight deploy
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   publish:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page-url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -73,38 +88,15 @@ jobs:
         shell: bash -l {0}
         run: |
           jb build lectures --path-output ./ -n -W --keep-going
-      # Create HTML archive for release assets
-      - name: Create HTML archive
-        shell: bash -l {0}
-        run: |
-          tar -czf lecture-jax-html-${{ github.ref_name }}.tar.gz -C _build/html .
-          sha256sum lecture-jax-html-${{ github.ref_name }}.tar.gz > html-checksum.txt
-
-          # Create metadata manifest
-          cat > html-manifest.json << EOF
-          {
-            "tag": "${{ github.ref_name }}",
-            "commit": "${{ github.sha }}",
-            "timestamp": "$(date -Iseconds)",
-            "size_mb": $(du -sm _build/html | cut -f1),
-            "file_count": $(find _build/html -type f | wc -l)
-          }
-          EOF
-      - name: Upload archives to release
-        uses: softprops/action-gh-release@v3
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: quantecon/actions/publish-gh-pages@v0.6.0
         with:
-          files: |
-            lecture-jax-html-${{ github.ref_name }}.tar.gz
-            html-checksum.txt
-            html-manifest.json
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Deploy website to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/html/
+          build-dir: _build/html
           cname: jax.quantecon.org
+          create-release-assets: 'true'
+          asset-name: 'lecture-jax-html'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare lecture-jax.notebooks sync
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
## What

Migrates GitHub Pages deployment from the legacy `gh-pages` branch method (`peaceiris/actions-gh-pages`) to native, artifact-based deployment, mirroring the family reference [lecture-dp](https://github.com/QuantEcon/lecture-dp). See QuantEcon/meta#282 for the overall strategy.

## Why

The `gh-pages` branch accumulates a full HTML snapshot on every publish, bloating the repo and slowing clones. Artifact-based deployment stores nothing in git — the deployed site lives in the Pages infrastructure — so the repo stays small and the `gh-pages` branch can be deleted.

## Changes (single file: `.github/workflows/publish.yml`)

- Add `pages`/`id-token` permissions and a `pages` concurrency group; run the `publish` job in the `github-pages` environment.
- Replace `peaceiris/actions-gh-pages@v4` with `quantecon/actions/publish-gh-pages@v0.6.0` (handles the CNAME `jax.quantecon.org` and creates release assets).
- Remove the manual HTML archive / checksum / manifest / `action-gh-release` steps — the action now produces those release assets (`asset-name: lecture-jax-html`).

**Unchanged:** the single-job **GPU** build (`g4dn.2xlarge`), the jax/CUDA install + GPU checks, LaTeX PDF, download-notebook build, and the sync to `lecture-jax.notebooks`. Per the migration guide, GPU repos keep a single job (rather than split build+deploy) to avoid transferring large build artifacts between runners.

## Note on release-asset filenames

The manifest/checksum filenames change slightly (the action names them `lecture-jax-html-checksum.txt` / `lecture-jax-html-manifest.json` rather than `html-checksum.txt` / `html-manifest.json`); the HTML tarball name `lecture-jax-html-<tag>.tar.gz` is unchanged. Nothing in the repo depends on the old names (there is no linkcheck workflow here).

## Required maintainer steps (settings — not in this PR)

The workflow change alone does not deploy. A repo admin must do the following, in order. Steps 2–3 must happen **before** the first tagged deploy or it will fail with *"Tag is not allowed to deploy to github-pages due to environment protection rules."*

1. Merge this PR.
2. **Settings → Pages → Source** → change to **"GitHub Actions"**.
3. **Settings → Environments → github-pages** → add a deployment rule of type **Tag** (not Branch) with the pattern `publish*`.
4. Push a `publish-*` tag to trigger a deploy, then verify: the site loads at https://jax.quantecon.org/, and `gh api repos/QuantEcon/lecture-jax/pages --jq '.build_type'` returns `workflow`.
5. Once the deploy is verified, delete the `gh-pages` branch: `git push origin --delete gh-pages`.

## Rollback

If anything goes wrong before `gh-pages` is deleted: set **Settings → Pages → Source** back to "Deploy from a branch" → `gh-pages`, and the previous site serves again immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
