### PR TITLE
Adopt minimal proof/exercise styling

### DIFF
--- a/lectures/_config.yml
+++ b/lectures/_config.yml
@@ -38,6 +38,9 @@ sphinx:
     bibtex_reference_style: author_year
     suppress_warnings: ["mystnb.unknown_mime_type"]
     nb_merge_streams: true
+    # sphinx-proof
+    proof_minimal_theme: true
+    # sphinx-exercise
     exercise_style: solution_follow_exercise
     # myst-nb config
     nb_render_image_options:


### PR DESCRIPTION
## What

Add `proof_minimal_theme: true` to `lectures/_config.yml` so proofs use the sphinx-proof **minimal** theme. The `exercise_style: solution_follow_exercise` knob is already set, so this brings `jax` fully in line.

## Why

Part of a cross-series harmonization so every proof-using Python lecture series uses the minimal proof theme. `jax` had the exercise style but not the minimal proof theme. See the audit and checklist in QuantEcon/workspace-lectures#13.

## Note

Config-only change; no lecture content touched.
