### PR TITLE
[preview] Migrate to quantecon/actions/preview-netlify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,13 +69,13 @@ jobs:
         with:
           name: execution-reports
           path: _build/html/reports
-      - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          publish-dir: '_build/html/'
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Preview Deploy from GitHub Actions"
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          node-version: '20'
+      - name: Preview Deploy to Netlify
+        uses: quantecon/actions/preview-netlify@v0.8.0
+        with:
+          netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
+          build-dir: _build/html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ on: [pull_request]
 jobs:
   preview:
     runs-on: "runs-on=${{ github.run_id }}/family=g4dn.2xlarge/image=quantecon_ubuntu2404/volume=80gb/spot=false"
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/collab.yml
+++ b/.github/workflows/collab.yml
@@ -48,13 +48,3 @@ jobs:
         with:
           name: execution-reports
           path: _build/html/reports
-      - name: Preview Deploy to Netlify
-        uses: nwtgck/actions-netlify@v4
-        with:
-          publish-dir: '_build/html/'
-          production-branch: main
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Preview Deploy from GitHub Actions"
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
This adopts the org-standard preview action and removes a redundant, racing Netlify deploy.

## What

**`ci.yml` — migrate to the org action.** Replaces the third-party `nwtgck/actions-netlify@v4` with `quantecon/actions/preview-netlify@v0.8.0` — the same version already used in `lecture-python.myst`. A `setup-node` step is added because the action installs the Netlify CLI via npm. Inputs move to `netlify-auth-token` / `netlify-site-id` / `build-dir`; `lectures-dir` defaults to `lectures`, which matches this repo.

**`collab.yml` — drop the redundant preview deploy.** The `execution-checks` job exists to test execution on the Colab runtime image. It was also deploying `_build/html/` to the same Netlify site as `ci.yml`, so the two jobs raced for the PR alias — and the Colab build omits the notebook and PDF download assets, so when it won the race the published preview was a degraded version. `ci.yml` now owns the single canonical preview.

## Why the new action is better

- Deploys via the **Netlify CLI** (tooling QuantEcon owns and versions) to a deterministic `pr-<number>` alias instead of racing on Netlify’s `deploy-preview-<number>`.
- Posts **one self-updating PR comment** (edits in place instead of stacking a new comment per push) with **direct links to the changed lecture pages**.
- **Safely skips dependabot and fork PRs** that cannot access secrets, so those runs no longer fail on the deploy step.

## Verification

Both workflow files validate as well-formed YAML locally. The real exercise is a live PR run: the `preview` job builds on the GPU runner and deploys, so this PR itself is the end-to-end test — check that a single `📖 Netlify Preview Ready!` comment appears and that the changed-page links resolve.

## Follow-up (dashboard, not in this repo)

The `netlify[bot]` native Deploy Preview is configured in the Netlify dashboard, not here, so it is unaffected by this change. To avoid two preview comments, disable Netlify’s automatic Deploy Previews in the site settings so this GitHub Actions preview is the only one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)